### PR TITLE
Hotfix/movement and army controller not using dtos

### DIFF
--- a/src/main/java/com/ardaslegends/presentation/api/ArmyRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/ArmyRestController.java
@@ -52,126 +52,148 @@ public class ArmyRestController extends AbstractRestController {
         return ResponseEntity.ok(pageResponse);
     }
     @PostMapping(PATH_CREATE_ARMY)
-    public HttpEntity<Army> createArmy(@RequestBody CreateArmyDto dto) {
+    public HttpEntity<ArmyResponse> createArmy(@RequestBody CreateArmyDto dto) {
         log.debug("Incoming createArmy Request: Data [{}]", dto);
 
         var units = armyService.convertUnitInputIntoUnits(dto.unitString());
         CreateArmyDto dtoWithUnits = new CreateArmyDto(dto.executorDiscordId(), dto.name(), dto.armyType(), dto.claimBuildName(), units);
         log.debug("Calling ArmyService.createArmy");
         Army createdArmy = wrappedServiceExecution(dtoWithUnits, armyService::createArmy);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(createdArmy);
 
         log.info("Sending successful createArmy Request for [{}]", createdArmy.getName());
-        return ResponseEntity.ok(createdArmy);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_BIND_ARMY)
-    public HttpEntity<Army> bindArmy(@RequestBody BindArmyDto dto) {
+    public HttpEntity<ArmyResponse> bindArmy(@RequestBody BindArmyDto dto) {
         log.debug("Incoming bindArmy Request: Data [{}]", dto);
 
         log.debug("Calling ArmyService.bind()");
         Army boundArmy = wrappedServiceExecution(dto, armyService::bind);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(boundArmy);
 
         log.info("Sending successful bindArmy request for [{}]", boundArmy.getName());
-        return ResponseEntity.ok(boundArmy);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_UNBIND_ARMY)
-    public HttpEntity<Army> unbindArmy(@RequestBody BindArmyDto dto) {
+    public HttpEntity<ArmyResponse> unbindArmy(@RequestBody BindArmyDto dto) {
         log.debug("Incoming unbindArmy Request: Data [{}]", dto);
 
         log.debug("Calling ArmyService.unbind()");
         Army unboundArmy = wrappedServiceExecution(dto, armyService::unbind);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(unboundArmy);
 
         log.info("Sending successful unbindArmy request for [{}]", unboundArmy.getName());
-        return ResponseEntity.ok(unboundArmy);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping(PATH_DISBAND_ARMY)
-    public HttpEntity<Army> disbandArmy(@RequestBody DeleteArmyDto dto) {
+    public HttpEntity<ArmyResponse> disbandArmy(@RequestBody DeleteArmyDto dto) {
         log.debug("Incoming disbandArmy Request: Data [{}]", dto);
 
         log.debug("Calling ArmyService.unbind()");
         Army disbandedArmy = wrappedServiceExecution(dto, false, armyService::disband);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(disbandedArmy);
 
         log.info("Sending successful disbandArmy request for [{}]", disbandedArmy.getName());
-        return ResponseEntity.ok(disbandedArmy);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping(PATH_DELETE_ARMY)
-    public HttpEntity<Army> deleteArmy(@RequestBody DeleteArmyDto dto) {
+    public HttpEntity<ArmyResponse> deleteArmy(@RequestBody DeleteArmyDto dto) {
         log.debug("Incoming deleteArmy Request: Data [{}]", dto);
 
         log.debug("Calling ArmyService.disband()");
         Army deletedArmy = wrappedServiceExecution(dto, true, armyService::disband);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(deletedArmy);
 
         log.info("Sending successful deleteArmy request for [{}]", deletedArmy.getName());
-        return ResponseEntity.ok(deletedArmy);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_START_HEALING)
-    public HttpEntity<Army> startHealing(@RequestBody UpdateArmyDto dto) {
+    public HttpEntity<ArmyResponse> startHealing(@RequestBody UpdateArmyDto dto) {
         log.debug("Incoming start healing Request: Data [{}]", dto);
 
         log.debug("Calling healStart()");
         Army modifiedArmy = wrappedServiceExecution(dto, armyService::healStart);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(modifiedArmy);
 
         log.info("Sending successful start healing Request for [{}]", modifiedArmy.toString());
-        return ResponseEntity.ok(modifiedArmy);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_STOP_HEALING)
-    public HttpEntity<Army> stopHealing(@RequestBody UpdateArmyDto dto) {
+    public HttpEntity<ArmyResponse> stopHealing(@RequestBody UpdateArmyDto dto) {
         log.debug("Incoming stop healing Request: Data [{}]", dto);
 
         log.debug("Calling healStop()");
         Army modifiedArmy = wrappedServiceExecution(dto, armyService::healStop);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(modifiedArmy);
 
         log.info("Sending successful stop healing Request for [{}]", modifiedArmy.toString());
-        return ResponseEntity.ok(modifiedArmy);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_STATION)
-    public HttpEntity<Army> station(@RequestBody StationDto dto) {
+    public HttpEntity<ArmyResponse> station(@RequestBody StationDto dto) {
         log.debug("Incoming station request: Data [{}]", dto);
 
         log.debug("Calling station()");
         Army modifiedArmy = wrappedServiceExecution(dto, armyService::station);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(modifiedArmy);
 
         log.info("Sending successful station request for [{}]", modifiedArmy.toString());
-        return ResponseEntity.ok(modifiedArmy);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_UNSTATION)
-    public HttpEntity<Army> unstation(@RequestBody StationDto dto) {
+    public HttpEntity<ArmyResponse> unstation(@RequestBody StationDto dto) {
         log.debug("Incoming station request: Data [{}]", dto);
 
         log.debug("Calling unstation()");
         Army modifiedArmy = wrappedServiceExecution(dto, armyService::unstation);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(modifiedArmy);
 
         log.info("Sending successful unstation request for [{}]", modifiedArmy.toString());
-        return ResponseEntity.ok(modifiedArmy);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_SET_FREE_TOKENS)
-    public HttpEntity<Army> setFreeArmyTokens(@RequestBody UpdateArmyDto dto) {
+    public HttpEntity<ArmyResponse> setFreeArmyTokens(@RequestBody UpdateArmyDto dto) {
         log.debug("Incoming setFreeArmyTokens Request: Data [{}]", dto);
 
         log.debug("Calling ArmyService.setFreeArmyTokens()");
         Army deletedArmy = wrappedServiceExecution(dto, armyService::setFreeArmyTokens);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(deletedArmy);
 
         log.info("Sending successful setFreeArmyTokens request for [{}]", deletedArmy.getName());
-        return ResponseEntity.ok(deletedArmy);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_PICK_SIEGE)
-    public HttpEntity<Army> pickSiege(@RequestBody PickSiegeDto dto) {
+    public HttpEntity<ArmyResponse> pickSiege(@RequestBody PickSiegeDto dto) {
         log.debug("Incoming pickSiege Request: Data [{}]", dto);
 
         log.debug("Calling ArmyService.pickSiege()");
         Army army = wrappedServiceExecution(dto, armyService::pickSiege);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(army);
 
         log.info("Sending successful pickSiege request for [{}]", army.getName());
-        return ResponseEntity.ok(army);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping(PATH_UPKEEP)
@@ -197,24 +219,28 @@ public class ArmyRestController extends AbstractRestController {
     }
 
     @PatchMapping(PATH_SET_IS_PAID)
-    public HttpEntity<Army> setIsPaid(@RequestBody UpdateArmyDto dto) {
+    public HttpEntity<ArmyResponse> setIsPaid(@RequestBody UpdateArmyDto dto) {
         log.debug("Incoming setIsPaid Request for army or company [{}]", dto);
 
         log.trace("Calling wrappedServiceExecution armyService.setIsPaid");
         var result = wrappedServiceExecution(dto, armyService::setIsPaid);
+        log.debug("Converting to ArmyResponse");
+        ArmyResponse response = new ArmyResponse(result);
 
         log.info("Sending setPaid Response, success [{}]", result);
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping(PATH_GET_UNPAID)
-    public HttpEntity<List<Army>> getUnpaid() {
+    public HttpEntity<List<ArmyResponse>> getUnpaid() {
         log.debug("Incoming getUnpaid Request");
 
         log.trace("Calling wrappedServiceExecution, armyService.getUnpaid");
         var result = wrappedServiceExecution(armyService::getUnpaid);
+        log.debug("Converting to ArmyResponse");
+        var response = result.stream().map(ArmyResponse::new).toList();
 
-        log.info("Sending getUnpaid Response, data [{}]", result);
-        return ResponseEntity.ok(result);
+        log.info("Sending getUnpaid Response, data [{}]", response);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
@@ -2,6 +2,7 @@ package com.ardaslegends.presentation.api;
 
 import com.ardaslegends.domain.Movement;
 import com.ardaslegends.presentation.AbstractRestController;
+import com.ardaslegends.presentation.api.response.movement.MovementResponse;
 import com.ardaslegends.service.MovementService;
 import com.ardaslegends.service.dto.army.MoveArmyDto;
 import com.ardaslegends.service.dto.player.DiscordIdDto;
@@ -30,46 +31,54 @@ public class MovementRestController extends AbstractRestController {
 
 
     @PostMapping(PATH_MOVE_CHAR)
-    public HttpEntity<Movement> moveRoleplayCharacter(@RequestBody MoveRpCharDto dto) {
+    public HttpEntity<MovementResponse> moveRoleplayCharacter(@RequestBody MoveRpCharDto dto) {
 
         log.debug("Incoming Post Request to create rp char movement, data [{}]", dto);
         log.trace("WrappedServiceExecution of createRpCharMovement function");
         Movement movement = wrappedServiceExecution(dto, movementService::createRpCharMovement);
+        log.debug("Creating MovementResponse");
+        MovementResponse response = new MovementResponse(movement);
 
         log.info("Successfully handled request for creating rpchar movement!");
-        return ResponseEntity.ok(movement);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_CANCEL_CHAR_MOVEMENT)
-    public HttpEntity<Movement> cancelRoleplayCharacterMove(@RequestBody DiscordIdDto dto) {
+    public HttpEntity<MovementResponse> cancelRoleplayCharacterMove(@RequestBody DiscordIdDto dto) {
 
         log.debug("Incoming Post Request to cancel rp char movement, data [{}]", dto);
         log.trace("WrappedServiceExecution of cancelRpCharMovement function");
         Movement movement = wrappedServiceExecution(dto, movementService::cancelRpCharMovement);
+        log.debug("Creating MovementResponse");
+        MovementResponse response = new MovementResponse(movement);
 
         log.info("Successfully handled request for cancelling rpchar movement!");
-        return ResponseEntity.ok(movement);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping(PATH_MOVE_ARMY)
-    public HttpEntity<Movement> moveArmy(@RequestBody MoveArmyDto dto) {
+    public HttpEntity<MovementResponse> moveArmy(@RequestBody MoveArmyDto dto) {
         log.debug("Incoming Post Request to create army movement, data [{}]", dto);
 
         log.trace("WrappedServiceExecution of createArmyMovement function");
         Movement movement = wrappedServiceExecution(dto, movementService::createArmyMovement);
+        log.debug("Creating MovementResponse");
+        MovementResponse response = new MovementResponse(movement);
 
         log.info("Successfully handled request for creating army movement!");
-        return ResponseEntity.ok(movement);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping(PATH_CANCEL_ARMY_MOVEMENT)
-    public HttpEntity<Movement> cancelArmyMove(@RequestBody MoveArmyDto dto) {
+    public HttpEntity<MovementResponse> cancelArmyMove(@RequestBody MoveArmyDto dto) {
 
         log.debug("Incoming Post Request to cancel army movement, data [{}]", dto);
         log.trace("WrappedServiceExecution of cancelArmyMovement function");
         Movement movement = wrappedServiceExecution(dto, movementService::cancelArmyMovement);
+        log.debug("Creating MovementResponse");
+        MovementResponse response = new MovementResponse(movement);
 
         log.info("Successfully handled request for cancelling army movement!");
-        return ResponseEntity.ok(movement);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ardaslegends/presentation/api/response/army/ArmyResponse.java
+++ b/src/main/java/com/ardaslegends/presentation/api/response/army/ArmyResponse.java
@@ -4,10 +4,11 @@ import com.ardaslegends.domain.Army;
 
 public record ArmyResponse(
         long id,
-        String nameOfArmy,
+        String name,
         String armyType,
-        String nameOfFaction,
-        String currentRegion
+        String faction,
+        String currentRegion,
+        String boundTo
 ) {
     public ArmyResponse(Army army) {
         this(
@@ -15,7 +16,8 @@ public record ArmyResponse(
                 army.getName(),
                 army.getArmyType().getName(),
                 army.getFaction().getName(),
-                army.getCurrentRegion().getId()
+                army.getCurrentRegion().getId(),
+                army.getBoundTo() == null ? null : army.getBoundTo().getName()
         );
     }
 }

--- a/src/main/java/com/ardaslegends/presentation/api/response/movement/MovementResponse.java
+++ b/src/main/java/com/ardaslegends/presentation/api/response/movement/MovementResponse.java
@@ -1,0 +1,44 @@
+package com.ardaslegends.presentation.api.response.movement;
+
+import com.ardaslegends.domain.Movement;
+import com.ardaslegends.presentation.api.response.army.ArmyResponse;
+import com.ardaslegends.presentation.api.response.movement.path.PathResponse;
+import com.ardaslegends.presentation.api.response.player.rpchar.RpCharResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+public record MovementResponse(
+    Long id,
+    RpCharResponse rpChar,
+    ArmyResponse army,
+    Boolean isCharMovement,
+    List<PathResponse> path,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    Boolean isCurrentlyActive,
+    Integer hoursUntilComplete,
+    Integer hoursAlreadyMoved,
+    Integer hoursUntilNextRegion
+
+) {
+
+    public MovementResponse(Movement movement) {
+        this(
+                movement.getId(),
+                movement.getRpChar() == null ? null : new RpCharResponse(movement.getRpChar()),
+                movement.getArmy() == null ? null : new ArmyResponse(movement.getArmy()),
+                movement.getIsCharMovement(),
+                movement.getPath().stream().map(PathResponse::new).toList(),
+                movement.getStartTime(),
+                movement.getEndTime(),
+                movement.getIsCurrentlyActive(),
+                movement.getHoursUntilComplete(),
+                movement.getHoursMoved(),
+                movement.getHoursUntilComplete()
+        );
+        log.debug("Created MovementResponse {}", this);
+    }
+}

--- a/src/main/java/com/ardaslegends/presentation/api/response/movement/path/PathResponse.java
+++ b/src/main/java/com/ardaslegends/presentation/api/response/movement/path/PathResponse.java
@@ -1,0 +1,21 @@
+package com.ardaslegends.presentation.api.response.movement.path;
+
+import com.ardaslegends.domain.PathElement;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public record PathResponse(
+    String region,
+    Integer baseCost,
+    Integer actualCost
+) {
+
+    public PathResponse(PathElement pathElement) {
+        this(
+                pathElement.getRegion().getId(),
+                pathElement.getBaseCost(),
+                pathElement.getActualCost()
+        );
+        log.debug("Created PathResponse {}", this);
+    }
+}

--- a/src/test/java/com/ardaslegends/presentation/api/ArmyRestControllerTest.java
+++ b/src/test/java/com/ardaslegends/presentation/api/ArmyRestControllerTest.java
@@ -1,6 +1,7 @@
 package com.ardaslegends.presentation.api;
 
-import com.ardaslegends.domain.Army;
+import com.ardaslegends.domain.*;
+import com.ardaslegends.presentation.api.response.army.ArmyResponse;
 import com.ardaslegends.service.ArmyService;
 import com.ardaslegends.service.dto.army.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,11 +11,16 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.mockito.Mockito.*;
@@ -28,8 +34,16 @@ public class ArmyRestControllerTest {
     private ArmyService mockArmyService;
     private ArmyRestController armyRestController;
 
+    private Army army;
+
     @BeforeEach
     void setup() {
+        val faction = Faction.builder().name("Gondor").build();
+        val region = Region.builder().id("10").neighboringRegions(new HashSet<>()).build();
+        val originalClaimbuild = ClaimBuild.builder().name("Nimheria").build();
+        army = new Army(1L, "Army Name", ArmyType.ARMY, faction, region, null,
+                new ArrayList<Unit>(), new ArrayList<String>(), null, 0.0, false, null, null, 0, 0,
+                originalClaimbuild, LocalDateTime.now(), new ArrayList<Movement>(), true);
         mockArmyService = mock(ArmyService.class);
         armyRestController = new ArmyRestController(mockArmyService);
         mockMvc = MockMvcBuilders.standaloneSetup(armyRestController).build();
@@ -42,7 +56,7 @@ public class ArmyRestControllerTest {
         // Assign
         CreateArmyDto dto = new CreateArmyDto(null, null, null, null, null, null);
 
-        when(mockArmyService.createArmy(dto)).thenReturn(new Army());
+        when(mockArmyService.createArmy(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -64,7 +78,7 @@ public class ArmyRestControllerTest {
         // Assign
         BindArmyDto dto = new BindArmyDto("1234", "1234", "Knights of Gondor");
 
-        when(mockArmyService.bind(dto)).thenReturn(new Army());
+        when(mockArmyService.bind(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -87,7 +101,7 @@ public class ArmyRestControllerTest {
         // Assign
         BindArmyDto dto = new BindArmyDto("1234", "1234", "Knights of Gondor");
 
-        when(mockArmyService.unbind(dto)).thenReturn(Army.builder().name("Knights of Gondor").build());
+        when(mockArmyService.unbind(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -110,7 +124,7 @@ public class ArmyRestControllerTest {
         // Assign
         DeleteArmyDto dto = new DeleteArmyDto("1234",  "Knights of Gondor");
 
-        when(mockArmyService.disband(dto, false)).thenReturn(Army.builder().name("Knights of Gondor").build());
+        when(mockArmyService.disband(dto, false)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -140,10 +154,9 @@ public class ArmyRestControllerTest {
 
         String requestJson = ow.writeValueAsString(dto);
 
-        val army = Army.builder().name("Knights Of Gondor").build();
-        when(mockArmyService.disband(dto, true)).thenReturn(army);
+        when(mockArmyService.disband(eq(dto), anyBoolean())).thenReturn(army);
 
-        String expectedResponse = ow.writeValueAsString(army);
+        String expectedResponse = ow.writeValueAsString(new ArmyResponse(army));
 
         mockMvc.perform(MockMvcRequestBuilders
                         .delete("http://localhost:8080/api/army/delete")
@@ -161,7 +174,7 @@ public class ArmyRestControllerTest {
         // Assign
         UpdateArmyDto dto = new UpdateArmyDto("kekw", "Knights of Gondor", null, null);
 
-        when(mockArmyService.healStart(dto)).thenReturn(new Army());
+        when(mockArmyService.healStart(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -184,7 +197,7 @@ public class ArmyRestControllerTest {
         // Assign
         UpdateArmyDto dto = new UpdateArmyDto("kekw", "Knights of Gondor", null, null);
 
-        when(mockArmyService.healStop(dto)).thenReturn(new Army());
+        when(mockArmyService.healStop(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -207,7 +220,7 @@ public class ArmyRestControllerTest {
         // Assign
         StationDto dto = new StationDto("Kek", "kek", "kek");
 
-        when(mockArmyService.station(dto)).thenReturn(new Army());
+        when(mockArmyService.station(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -229,7 +242,7 @@ public class ArmyRestControllerTest {
         // Assign
         StationDto dto = new StationDto("Kek", "kek", "kek");
 
-        when(mockArmyService.unstation(dto)).thenReturn(new Army());
+        when(mockArmyService.unstation(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -251,7 +264,7 @@ public class ArmyRestControllerTest {
         // Assign
         UpdateArmyDto dto = new UpdateArmyDto(null, "Knights of Gondor", 20.0, null);
 
-        when(mockArmyService.setFreeArmyTokens(dto)).thenReturn(Army.builder().name("Knights of Gondor").build());
+        when(mockArmyService.setFreeArmyTokens(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -274,7 +287,7 @@ public class ArmyRestControllerTest {
         // Assign
         PickSiegeDto dto = new PickSiegeDto("1234", "Knights of Gondor", "Gondor CB", "Trebuchet");
 
-        when(mockArmyService.pickSiege(dto)).thenReturn(Army.builder().name("Knights of Gondor").build());
+        when(mockArmyService.pickSiege(dto)).thenReturn(army);
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
@@ -323,6 +336,8 @@ public class ArmyRestControllerTest {
 
         String requestJson = ow.writeValueAsString(dto);
 
+        when(mockArmyService.setIsPaid(dto)).thenReturn(army);
+
         mockMvc.perform(MockMvcRequestBuilders
                         .patch("http://localhost:8080/api/army/setPaid")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -334,7 +349,7 @@ public class ArmyRestControllerTest {
     void ensureGetUnpaidWorksProperly() throws Exception {
         log.debug("Testing if ArmyRestController getUnpaid works properly");
 
-        List<Army> army = List.of(Army.builder().name("kek").build());
+        List<Army> army = List.of(this.army);
 
         when(mockArmyService.getUnpaid()).thenReturn(army);
 


### PR DESCRIPTION
## Issue
The MovementRestController as well as the ArmyRestController used the domain layer classes as return types (`Army` and `Movement`). This not only exposed our domain layer to the REST API, creating potential serialization issues with Jackson, but also introduced a bug where the Swagger UI gets stuck when trying to look at the documentation of said Rest Controllers

## Fixes

- Introduced `MovementResponse`
- Introduced `PathResponse`
- Made all `MovementRestController` endpoints use `MovementResponse`
- Made all `ArmyRestController` endpoints use the already existing `ArmyResponse` 