### PR TITLE
Fixed MovementResponse using the wrong value for hoursUntilNextRegion

### DIFF
--- a/src/main/java/com/ardaslegends/presentation/api/response/movement/MovementResponse.java
+++ b/src/main/java/com/ardaslegends/presentation/api/response/movement/MovementResponse.java
@@ -37,7 +37,7 @@ public record MovementResponse(
                 movement.getIsCurrentlyActive(),
                 movement.getHoursUntilComplete(),
                 movement.getHoursMoved(),
-                movement.getHoursUntilComplete()
+                movement.getHoursUntilNextRegion()
         );
         log.debug("Created MovementResponse {}", this);
     }


### PR DESCRIPTION
Fixed `MovementResponse.hoursUntilNextRegion` falsely using the value of `Movement.getHoursUntilComplete()` instead of `Movement.getHoursUntilNextRegion()`

closes #128 