### PR TITLE
Removed useless claimbuild unstation parameter

### DIFF
--- a/src/main/java/com/ardaslegends/presentation/api/ArmyRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/ArmyRestController.java
@@ -158,7 +158,7 @@ public class ArmyRestController extends AbstractRestController {
     }
 
     @PatchMapping(PATH_UNSTATION)
-    public HttpEntity<ArmyResponse> unstation(@RequestBody StationDto dto) {
+    public HttpEntity<ArmyResponse> unstation(@RequestBody UnstationDto dto) {
         log.debug("Incoming station request: Data [{}]", dto);
 
         log.debug("Calling unstation()");

--- a/src/main/java/com/ardaslegends/presentation/discord/commands/unstation/UnstationArmyOrCompanyCommand.java
+++ b/src/main/java/com/ardaslegends/presentation/discord/commands/unstation/UnstationArmyOrCompanyCommand.java
@@ -9,6 +9,7 @@ import com.ardaslegends.presentation.discord.utils.ALColor;
 import com.ardaslegends.presentation.discord.utils.Thumbnails;
 import com.ardaslegends.service.ArmyService;
 import com.ardaslegends.service.dto.army.StationDto;
+import com.ardaslegends.service.dto.army.UnstationDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
@@ -37,7 +38,7 @@ public class UnstationArmyOrCompanyCommand implements ALCommandExecutor {
         log.debug("armyName: [{}]", armyName);
 
         log.trace("Building dto");
-        StationDto dto = new StationDto(user.getIdAsString(), armyName, null);
+        UnstationDto dto = new UnstationDto(user.getIdAsString(), armyName);
         log.debug("Built dto with data [{}]", dto);
 
         log.trace("Calling armyService");

--- a/src/main/java/com/ardaslegends/service/ArmyService.java
+++ b/src/main/java/com/ardaslegends/service/ArmyService.java
@@ -493,7 +493,7 @@ public class ArmyService extends AbstractService<Army, ArmyRepository> {
     }
 
     @Transactional(readOnly = false)
-    public Army unstation(StationDto dto) {
+    public Army unstation(UnstationDto dto) {
         log.debug("Trying to unstation army with data: [{}]", dto);
 
         ServiceUtils.checkNulls(dto, List.of("executorDiscordId", "armyName"));

--- a/src/main/java/com/ardaslegends/service/dto/army/UnstationDto.java
+++ b/src/main/java/com/ardaslegends/service/dto/army/UnstationDto.java
@@ -1,0 +1,4 @@
+package com.ardaslegends.service.dto.army;
+
+public record UnstationDto(String executorDiscordId, String armyName) {
+}

--- a/src/test/java/com/ardaslegends/presentation/api/ArmyRestControllerTest.java
+++ b/src/test/java/com/ardaslegends/presentation/api/ArmyRestControllerTest.java
@@ -240,7 +240,7 @@ public class ArmyRestControllerTest {
         log.debug("Testing if ArmyRestController unstation works properly with correct values");
 
         // Assign
-        StationDto dto = new StationDto("Kek", "kek", "kek");
+        UnstationDto dto = new UnstationDto("Kek", "kek");
 
         when(mockArmyService.unstation(dto)).thenReturn(army);
 

--- a/src/test/java/com/ardaslegends/service/ArmyServiceTest.java
+++ b/src/test/java/com/ardaslegends/service/ArmyServiceTest.java
@@ -439,7 +439,7 @@ public class ArmyServiceTest {
 
         army.setBoundTo(player.getActiveCharacter().get());
 
-        StationDto dto = new StationDto(player.getDiscordID(), army.getName(), null);
+        UnstationDto dto = new UnstationDto(player.getDiscordID(), army.getName());
 
         log.debug("Calling unstation, expecting no errors");
         var result = armyService.unstation(dto);
@@ -453,7 +453,7 @@ public class ArmyServiceTest {
 
         army.setStationedAt(null);
 
-        StationDto dto = new StationDto(player.getDiscordID(), army.getName(), null);
+        UnstationDto dto = new UnstationDto(player.getDiscordID(), army.getName());
 
         log.debug("calling unstation(), expecting Se");
         var result = assertThrows(ArmyServiceException.class, () -> armyService.unstation(dto));
@@ -468,7 +468,7 @@ public class ArmyServiceTest {
 
         army.setBoundTo(null);
 
-        StationDto dto = new StationDto(player.getDiscordID(), army.getName(), null);
+        UnstationDto dto = new UnstationDto(player.getDiscordID(), army.getName());
 
         log.debug("Calling unstation(), expecting Se");
         var result = assertThrows(ArmyServiceException.class, () -> armyService.unstation(dto));


### PR DESCRIPTION
- Old paramaters [executorDiscordId, armyName, claimbuildName]
- New paramaters [executorDiscordId, armyName]

closes #122 