### PR TITLE
Fetch and Calculate Movement Endpoints

### DIFF
--- a/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
@@ -50,6 +50,19 @@ public class MovementRestController extends AbstractRestController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping(PATH_GET_ARMY_MOVEMENTS)
+    public HttpEntity<CurrentAndPastMovementResponse> getCharMovements(String charName) {
+        log.debug("Incoming get request for previous rpChar movements [{}]", charName);
+
+        val movements = wrappedServiceExecution(charName, movementService::getCharMovements);
+
+        log.debug("Building response");
+        val response = new CurrentAndPastMovementResponse(movements.getFirst().orElse(null), movements.getSecond());
+
+        log.info("Successfully handled request, getCharMovements");
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping(PATH_CALCULATE_ARMY_MOVEMENT)
     public HttpEntity<MovementResponse> calculateArmyMove(MoveArmyDto dto) {
         log.debug("Incoming get request for army movement calculation [{}]", dto);

--- a/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
@@ -9,6 +9,7 @@ import com.ardaslegends.service.dto.player.DiscordIdDto;
 import com.ardaslegends.service.dto.player.rpchar.MoveRpCharDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +30,21 @@ public class MovementRestController extends AbstractRestController {
     public static final String PATH_CANCEL_CHAR_MOVEMENT = "/cancel-char-move";
     public static final String PATH_CANCEL_ARMY_MOVEMENT = "/cancel-army-move";
 
+    public static final String PATH_CALCULATE_ARMY_MOVEMENT = "/calculate/army";
+    public static final String PATH_CALCULATE_CHAR_MOVEMENT = "/calculate/char";
 
+    @GetMapping(PATH_CALCULATE_ARMY_MOVEMENT)
+    public HttpEntity<MovementResponse> calculateArmyMove(MoveArmyDto dto) {
+        log.debug("Incoming get request for army movement calculation [{}]", dto);
+
+        log.trace("WrappedServiceExecution of calculateArmyMovement function");
+        val movement = wrappedServiceExecution(dto, movementService::calculateArmyMovement);
+        log.debug("Creating MovementResponse");
+        MovementResponse response = new MovementResponse(movement);
+
+        log.info("Successfully handled request - calculated army movement!");
+        return ResponseEntity.ok(response);
+    }
     @PostMapping(PATH_MOVE_CHAR)
     public HttpEntity<MovementResponse> moveRoleplayCharacter(@RequestBody MoveRpCharDto dto) {
 

--- a/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
@@ -45,6 +45,19 @@ public class MovementRestController extends AbstractRestController {
         log.info("Successfully handled request - calculated army movement!");
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping(PATH_CALCULATE_CHAR_MOVEMENT)
+    public HttpEntity<MovementResponse> calculateCharMove(MoveRpCharDto dto) {
+        log.debug("Incoming get request for char movement calculation [{}]", dto);
+
+        log.trace("WrappedServiceExecution of calculateRpCharMovement function");
+        val movement = wrappedServiceExecution(dto, movementService::calculateRpCharMovement);
+        log.debug("Creating MovementResponse");
+        MovementResponse response = new MovementResponse(movement);
+
+        log.info("Successfully handled request - calculated char movement!");
+        return ResponseEntity.ok(response);
+    }
     @PostMapping(PATH_MOVE_CHAR)
     public HttpEntity<MovementResponse> moveRoleplayCharacter(@RequestBody MoveRpCharDto dto) {
 

--- a/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
@@ -50,7 +50,7 @@ public class MovementRestController extends AbstractRestController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping(PATH_GET_ARMY_MOVEMENTS)
+    @GetMapping(PATH_GET_CHAR_MOVEMENTS)
     public HttpEntity<CurrentAndPastMovementResponse> getCharMovements(String charName) {
         log.debug("Incoming get request for previous rpChar movements [{}]", charName);
 

--- a/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
@@ -38,10 +38,10 @@ public class MovementRestController extends AbstractRestController {
     public static final String PATH_CALCULATE_CHAR_MOVEMENT = "/calculate/char";
 
     @GetMapping(PATH_GET_ARMY_MOVEMENTS)
-    public HttpEntity<CurrentAndPastMovementResponse> getArmyMovements(String armyName) {
-        log.debug("Incoming get request for previous army movements [{}]", armyName);
+    public HttpEntity<CurrentAndPastMovementResponse> getArmyMovements(String name) {
+        log.debug("Incoming get request for previous army movements [{}]", name);
 
-        val movements = wrappedServiceExecution(armyName, movementService::getArmyMovements);
+        val movements = wrappedServiceExecution(name, movementService::getArmyMovements);
 
         log.debug("Building response");
         val response = new CurrentAndPastMovementResponse(movements.getFirst().orElse(null), movements.getSecond());
@@ -51,10 +51,10 @@ public class MovementRestController extends AbstractRestController {
     }
 
     @GetMapping(PATH_GET_CHAR_MOVEMENTS)
-    public HttpEntity<CurrentAndPastMovementResponse> getCharMovements(String charName) {
-        log.debug("Incoming get request for previous rpChar movements [{}]", charName);
+    public HttpEntity<CurrentAndPastMovementResponse> getCharMovements(String name) {
+        log.debug("Incoming get request for previous rpChar movements [{}]", name);
 
-        val movements = wrappedServiceExecution(charName, movementService::getCharMovements);
+        val movements = wrappedServiceExecution(name, movementService::getCharMovements);
 
         log.debug("Building response");
         val response = new CurrentAndPastMovementResponse(movements.getFirst().orElse(null), movements.getSecond());

--- a/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/MovementRestController.java
@@ -2,11 +2,13 @@ package com.ardaslegends.presentation.api;
 
 import com.ardaslegends.domain.Movement;
 import com.ardaslegends.presentation.AbstractRestController;
+import com.ardaslegends.presentation.api.response.movement.CurrentAndPastMovementResponse;
 import com.ardaslegends.presentation.api.response.movement.MovementResponse;
 import com.ardaslegends.service.MovementService;
 import com.ardaslegends.service.dto.army.MoveArmyDto;
 import com.ardaslegends.service.dto.player.DiscordIdDto;
 import com.ardaslegends.service.dto.player.rpchar.MoveRpCharDto;
+import com.mysema.commons.lang.Pair;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -24,6 +26,8 @@ public class MovementRestController extends AbstractRestController {
     private final MovementService movementService;
 
     public static final String BASE_URL = "/api/movement";
+    public static final String PATH_GET_ARMY_MOVEMENTS = "/army";
+    public static final String PATH_GET_CHAR_MOVEMENTS = "/char";
 
     public static final String PATH_MOVE_CHAR = "/move-char";
     public static final String PATH_MOVE_ARMY = "/move-army-or-company";
@@ -32,6 +36,19 @@ public class MovementRestController extends AbstractRestController {
 
     public static final String PATH_CALCULATE_ARMY_MOVEMENT = "/calculate/army";
     public static final String PATH_CALCULATE_CHAR_MOVEMENT = "/calculate/char";
+
+    @GetMapping(PATH_GET_ARMY_MOVEMENTS)
+    public HttpEntity<CurrentAndPastMovementResponse> getArmyMovements(String armyName) {
+        log.debug("Incoming get request for previous army movements [{}]", armyName);
+
+        val movements = wrappedServiceExecution(armyName, movementService::getArmyMovements);
+
+        log.debug("Building response");
+        val response = new CurrentAndPastMovementResponse(movements.getFirst().orElse(null), movements.getSecond());
+
+        log.info("Successfully handled request, getArmyMovements");
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping(PATH_CALCULATE_ARMY_MOVEMENT)
     public HttpEntity<MovementResponse> calculateArmyMove(MoveArmyDto dto) {

--- a/src/main/java/com/ardaslegends/presentation/api/response/movement/CurrentAndPastMovementResponse.java
+++ b/src/main/java/com/ardaslegends/presentation/api/response/movement/CurrentAndPastMovementResponse.java
@@ -1,0 +1,19 @@
+package com.ardaslegends.presentation.api.response.movement;
+
+import com.ardaslegends.domain.Movement;
+import org.springframework.data.util.Pair;
+
+import java.util.List;
+import java.util.Optional;
+
+public record CurrentAndPastMovementResponse(
+        MovementResponse currentMovement,
+        List<MovementResponse> pastMovements
+) {
+    public CurrentAndPastMovementResponse(Movement currentMovement, List<Movement> pastMovements) {
+        this(
+                currentMovement == null ? null : new MovementResponse(currentMovement),
+                pastMovements.stream().map(MovementResponse::new).toList()
+        );
+    }
+}

--- a/src/main/java/com/ardaslegends/repository/MovementRepository.java
+++ b/src/main/java/com/ardaslegends/repository/MovementRepository.java
@@ -15,6 +15,7 @@ public interface MovementRepository extends JpaRepository<Movement, Long> {
     //TODO add Test
     public List<Movement> findMovementsByRpChar(RPChar rpChar);
     public List<Movement> findMovementByArmyAndIsCurrentlyActiveFalse(Army army);
+    public List<Movement> findMovementByRpCharAndIsCurrentlyActiveFalse(RPChar rpChar);
     public Optional<Movement> findMovementByArmyAndIsCurrentlyActiveTrue(Army army);
     public Optional<Movement> findMovementByRpCharAndIsCurrentlyActiveTrue(RPChar rpChar);
     public List<Movement> findMovementsByIsCurrentlyActive(Boolean isActive);

--- a/src/main/java/com/ardaslegends/repository/MovementRepository.java
+++ b/src/main/java/com/ardaslegends/repository/MovementRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public interface MovementRepository extends JpaRepository<Movement, Long> {
     //TODO add Test
     public List<Movement> findMovementsByRpChar(RPChar rpChar);
+    public List<Movement> findMovementByArmyAndIsCurrentlyActiveFalse(Army army);
     public Optional<Movement> findMovementByArmyAndIsCurrentlyActiveTrue(Army army);
     public Optional<Movement> findMovementByRpCharAndIsCurrentlyActiveTrue(RPChar rpChar);
     public List<Movement> findMovementsByIsCurrentlyActive(Boolean isActive);

--- a/src/main/java/com/ardaslegends/repository/rpchar/RpcharRepository.java
+++ b/src/main/java/com/ardaslegends/repository/rpchar/RpcharRepository.java
@@ -4,6 +4,9 @@ import com.ardaslegends.domain.RPChar;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RpcharRepository extends JpaRepository<RPChar, Long>, RpcharRepositoryCustom {
+    Optional<RPChar> findRpcharByName(String name);
 }

--- a/src/main/java/com/ardaslegends/service/MovementService.java
+++ b/src/main/java/com/ardaslegends/service/MovementService.java
@@ -40,6 +40,7 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
     private final PlayerRepository playerRepository;
     private final PlayerService playerService;
     private final Pathfinder pathfinder;
+    private final RpCharService rpCharService;
 
     // TODO: Check if time is frozen -> if yes, cancel request
     // TODO: Check if army is in a battle -> if yes, cancel request
@@ -289,6 +290,21 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
 
         log.trace("Fetching past movements of army [{}]", army.getName());
         val pastMovements = secureFind(army, movementRepository::findMovementByArmyAndIsCurrentlyActiveFalse);
+
+        return Pair.of(currentMovement, pastMovements);
+    }
+
+    public Pair<Optional<Movement>, List<Movement>> getCharMovements(@NonNull String charName) {
+        log.debug("Trying to get movements for char [{}]", charName);
+
+        log.trace("Fetching char with name [{}]", charName);
+        val character = rpCharService.getRpCharByName(charName)
+
+        log.trace("Fetching current movement for char [{}]", charName);
+        val currentMovement = secureFind(character, movementRepository::findMovementByRpCharAndIsCurrentlyActiveTrue);
+
+        log.trace("Fetching past movements of char [{}]", character.getName());
+        val pastMovements = secureFind(character, movementRepository::findMovementByRpCharAndIsCurrentlyActiveFalse);
 
         return Pair.of(currentMovement, pastMovements);
     }

--- a/src/main/java/com/ardaslegends/service/MovementService.java
+++ b/src/main/java/com/ardaslegends/service/MovementService.java
@@ -46,7 +46,7 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
     public Movement createArmyMovement(MoveArmyDto dto) {
         log.debug("Trying to move Army [{}] executed by [{}] to Region [{}]", dto.armyName(), dto.executorDiscordId(), dto.toRegion());
 
-        Movement movement = calculateMovement(dto);
+        Movement movement = calculateArmyMovement(dto);
 
         log.debug("Saving Movement to database");
         secureSave(movement, movementRepository);
@@ -55,7 +55,7 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
         return movement;
     }
 
-    public Movement calculateMovement(MoveArmyDto dto) {
+    public Movement calculateArmyMovement(MoveArmyDto dto) {
         ServiceUtils.checkAllNulls(dto);
         ServiceUtils.checkAllBlanks(dto);
 
@@ -158,8 +158,16 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
     public Movement createRpCharMovement(MoveRpCharDto dto) {
         log.debug("Moving RpChar of player {} to Region {}", dto.discordId(), dto.toRegion());
 
-        //Validating data
+        var movement = calculateRpCharMovement(dto);
 
+        log.trace("Saving the new movement");
+        movement = secureSave(movement, movementRepository);
+
+        log.info("Successfully created new Movement for the RPChar '{}'", movement.getRpChar().getName());
+        return movement;
+    }
+
+    public Movement calculateRpCharMovement(MoveRpCharDto dto) {
         log.trace("Validating Data");
         ServiceUtils.checkAllNulls(dto);
         ServiceUtils.checkAllBlanks(dto);
@@ -231,10 +239,6 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
         int hoursUntilNextRegion = path.get(1).getActualCost();
         Movement movement = new Movement(rpChar, null, true, path, currentTime, currentTime.plusHours(hoursUntilDone), true, hoursUntilDone, hoursUntilNextRegion, 0);
 
-        log.trace("Saving the new movement");
-        movement = secureSave(movement, movementRepository);
-
-        log.info("Successfully created new Movement for the RPChar '{}' of Player '{}'", rpChar.getName(), player);
         return movement;
     }
 

--- a/src/main/java/com/ardaslegends/service/MovementService.java
+++ b/src/main/java/com/ardaslegends/service/MovementService.java
@@ -5,7 +5,6 @@ import com.ardaslegends.repository.ArmyRepository;
 import com.ardaslegends.repository.MovementRepository;
 import com.ardaslegends.repository.player.PlayerRepository;
 import com.ardaslegends.repository.region.RegionRepository;
-import com.ardaslegends.service.dto.army.GetArmyMovementsDto;
 import com.ardaslegends.service.dto.army.MoveArmyDto;
 import com.ardaslegends.service.dto.player.DiscordIdDto;
 import com.ardaslegends.service.dto.player.rpchar.MoveRpCharDto;

--- a/src/main/java/com/ardaslegends/service/MovementService.java
+++ b/src/main/java/com/ardaslegends/service/MovementService.java
@@ -298,7 +298,7 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
         log.debug("Trying to get movements for char [{}]", charName);
 
         log.trace("Fetching char with name [{}]", charName);
-        val character = rpCharService.getRpCharByName(charName)
+        val character = rpCharService.getRpCharByName(charName);
 
         log.trace("Fetching current movement for char [{}]", charName);
         val currentMovement = secureFind(character, movementRepository::findMovementByRpCharAndIsCurrentlyActiveTrue);

--- a/src/main/java/com/ardaslegends/service/MovementService.java
+++ b/src/main/java/com/ardaslegends/service/MovementService.java
@@ -14,6 +14,7 @@ import com.ardaslegends.service.exceptions.ServiceException;
 import com.ardaslegends.service.exceptions.logic.army.ArmyServiceException;
 import com.ardaslegends.service.exceptions.logic.movement.MovementServiceException;
 import com.ardaslegends.service.utils.ServiceUtils;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -278,14 +279,11 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
         return movement;
     }
 
-    public Pair<Optional<Movement>, List<Movement>> getArmyMovements(GetArmyMovementsDto dto) {
-        ServiceUtils.checkAllNulls(dto);
-        ServiceUtils.checkAllBlanks(dto);
+    public Pair<Optional<Movement>, List<Movement>> getArmyMovements(@NonNull String armyName) {
+        log.debug("Trying to get movements for army [{}]", armyName);
 
-        log.debug("Trying to get movements for army [{}]", dto.armyName());
-
-        log.trace("Fetching Army with name [{}]", dto.armyName());
-        val army = armyService.getArmyByName(dto.armyName());
+        log.trace("Fetching Army with name [{}]", armyName);
+        val army = armyService.getArmyByName(armyName);
 
         log.trace("Fetching current movement for army [{}]", army.getName());
         val currentMovement = secureFind(army, movementRepository::findMovementByArmyAndIsCurrentlyActiveTrue);

--- a/src/main/java/com/ardaslegends/service/RpCharService.java
+++ b/src/main/java/com/ardaslegends/service/RpCharService.java
@@ -4,8 +4,10 @@ import com.ardaslegends.domain.RPChar;
 import com.ardaslegends.repository.rpchar.RpcharRepository;
 import com.ardaslegends.service.exceptions.logic.rpchar.RpCharServiceException;
 import com.ardaslegends.service.utils.ServiceUtils;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -45,5 +47,18 @@ public class RpCharService extends AbstractService<RPChar, RpcharRepository>{
         return fetchedChars;
     }
 
+    public RPChar getRpCharByName(@NonNull String name) {
+        log.debug("Getting RpChar with name [{}]", name);
 
+        log.debug("Fetching Rpchar with name [{}]", name);
+        val character = rpcharRepository.findRpcharByName(name);
+
+        if(character.isEmpty()) {
+            log.warn("No RpChar found with name [{}]", name);
+            throw RpCharServiceException.noRpCharFound(name);
+        }
+
+        log.debug("Successfully returning RpChar with name [{}]", name);
+        return character.get();
+    }
 }

--- a/src/main/java/com/ardaslegends/service/dto/army/GetArmyMovementsDto.java
+++ b/src/main/java/com/ardaslegends/service/dto/army/GetArmyMovementsDto.java
@@ -1,4 +1,0 @@
-package com.ardaslegends.service.dto.army;
-
-public record GetArmyMovementsDto(String armyName, boolean pastMovements) {
-}

--- a/src/main/java/com/ardaslegends/service/dto/army/GetArmyMovementsDto.java
+++ b/src/main/java/com/ardaslegends/service/dto/army/GetArmyMovementsDto.java
@@ -1,0 +1,4 @@
+package com.ardaslegends.service.dto.army;
+
+public record GetArmyMovementsDto(String armyName, boolean pastMovements) {
+}

--- a/src/test/java/com/ardaslegends/presentation/api/MovementRestControllerTest.java
+++ b/src/test/java/com/ardaslegends/presentation/api/MovementRestControllerTest.java
@@ -4,6 +4,7 @@ import com.ardaslegends.domain.Movement;
 import com.ardaslegends.domain.PathElement;
 import com.ardaslegends.domain.Region;
 import com.ardaslegends.domain.RegionType;
+import com.ardaslegends.presentation.abstraction.ControllerUnitTest;
 import com.ardaslegends.service.MovementService;
 import com.ardaslegends.service.dto.army.MoveArmyDto;
 import com.ardaslegends.service.dto.player.DiscordIdDto;
@@ -12,6 +13,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.hc.core5.net.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -22,6 +25,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -39,7 +43,6 @@ public class MovementRestControllerTest {
     private PathElement pathElement;
     private PathElement pathElement2;
     private List<PathElement> path;
-
 
     @BeforeEach
     void setup() {
@@ -77,6 +80,47 @@ public class MovementRestControllerTest {
                         .post("http://localhost:8080/api/movement/move-char")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestJson))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void ensureCalculateArmyMovementRouteExists() throws Exception {
+        log.debug("Testing if calculateArmyMovement Route exists");
+
+        log.trace("Initializing Dto");
+        MoveArmyDto dto = new MoveArmyDto("RandoId", "test","12.S");
+
+        log.trace("Initialize return movement");
+        Movement movement = Movement.builder().path(path).build();
+
+        when(mockMovementService.calculateArmyMovement(dto)).thenReturn(movement);
+        val pathUri = new URIBuilder("https://localhost:8080/api/movement" + MovementRestController.PATH_CALCULATE_ARMY_MOVEMENT)
+                .addParameter("executorDiscordId", dto.executorDiscordId())
+                .addParameter("armyName", dto.armyName())
+                .addParameter("toRegion", dto.toRegion());
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get(pathUri.build()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void ensureCalculateCharMovementRouteExists() throws Exception {
+        log.debug("Testing if calculateCharMovement Route exists");
+
+        log.trace("Initializing Dto");
+        MoveRpCharDto dto = new MoveRpCharDto("RandoId","12.S");
+
+        log.trace("Initialize return movement");
+        Movement movement = Movement.builder().path(path).build();
+
+        when(mockMovementService.calculateRpCharMovement(dto)).thenReturn(movement);
+        val pathUri = new URIBuilder("https://localhost:8080/api/movement" + MovementRestController.PATH_CALCULATE_CHAR_MOVEMENT)
+                .addParameter("discordId", dto.discordId())
+                .addParameter("toRegion", dto.toRegion());
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get(pathUri.build()))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/ardaslegends/service/MovementServiceTest.java
+++ b/src/test/java/com/ardaslegends/service/MovementServiceTest.java
@@ -38,6 +38,7 @@ public class MovementServiceTest {
     private PlayerRepository mockPlayerRepository;
     private PlayerService mockPlayerService;
     private Pathfinder mockPathfinder;
+    private RpCharService mockRpCharService;
 
     private MovementService movementService;
 
@@ -64,7 +65,8 @@ public class MovementServiceTest {
         mockArmyRepository = mock(ArmyRepository.class);
         mockArmyService = mock(ArmyService.class);
         mockPathfinder = mock(Pathfinder.class);
-        movementService = new MovementService(mockMovementRepository, mockRegionRepository, mockArmyRepository, mockArmyService, mockPlayerRepository, mockPlayerService, mockPathfinder);
+        mockRpCharService = mock(RpCharService.class);
+        movementService = new MovementService(mockMovementRepository, mockRegionRepository, mockArmyRepository, mockArmyService, mockPlayerRepository, mockPlayerService, mockPathfinder, mockRpCharService);
 
         region1 = Region.builder().id("90").regionType(RegionType.LAND).build();
         region2 = Region.builder().id("91").regionType(RegionType.LAND).build();


### PR DESCRIPTION
Added 4 new endpoints. 

### Calculate Movement Endpoints
These two endpoints exist so that the user, before they apply the movements to their armies or characters, can see the path the movement will take as well as the duration and other information. 

1. Calculate Army Movement - GET/api/movement/calculate/army
2. Calculate Char Movement - GET/api/movement/calculate/char

### Get Movements
When calling these endpoints, the application will return the current movement and the past movements of the army or character.
If there is no active movement, then that field in the response will be null.

3. Get Army Movements - GET/api/movement/army
4. Get Char Movements - GET/api/movement/char

Closes #127 