### PR TITLE
Feature#144/new discord message interface

### DIFF
--- a/src/main/java/com/ardaslegends/service/discord/DiscordService.java
+++ b/src/main/java/com/ardaslegends/service/discord/DiscordService.java
@@ -40,6 +40,16 @@ public class DiscordService {
         return sendMessage(message, botProperties.getGeneralRpCommandsChannel());
     }
 
+    public Message sendMessageToClaimbuildAppChannel(ALMessage message) {
+        log.debug("Trying to send message [{}] to Claimbuild Application Channel", message);
+        return sendMessage(message, botProperties.getClaimbuildAppsChannel());
+    }
+
+    public Message sendMessageToRpCharAppChannel(ALMessage message) {
+        log.debug("Trying to send message [{}] to RpChar Application Channel", message);
+        return sendMessage(message, botProperties.getRpAppsChannel());
+    }
+
     private Message sendMessage(ALMessage message, TextChannel channel) {
         log.debug("Trying to send message [{}] to channel [{}]", message, channel.getIdAsString());
 

--- a/src/main/java/com/ardaslegends/service/discord/DiscordService.java
+++ b/src/main/java/com/ardaslegends/service/discord/DiscordService.java
@@ -1,13 +1,18 @@
 package com.ardaslegends.service.discord;
 
+import com.ardaslegends.presentation.discord.commands.ALMessageResponse;
 import com.ardaslegends.presentation.discord.config.BotProperties;
+import com.ardaslegends.service.discord.messages.ALMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.permission.Role;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -28,5 +33,29 @@ public class DiscordService {
         else
             log.debug("No role with id [{}] found", roleId);
         return foundRole;
+    }
+
+    public Message sendMessageToRpChannel(ALMessage message) {
+        log.debug("Trying to send message [{}] to Roleplay Channel", message);
+        return sendMessage(message, botProperties.getGeneralRpCommandsChannel());
+    }
+
+    private Message sendMessage(ALMessage message, TextChannel channel) {
+        log.debug("Trying to send message [{}] to channel [{}]", message, channel.getIdAsString());
+
+        Objects.requireNonNull(message, "Message was null!");
+        Objects.requireNonNull(channel, "TextChannel was null!");
+
+        Message returnMessage = null;
+        if(message.hasMessage()) {
+            log.debug("Message has a message [{}]", message.message());
+            returnMessage = message.message().send(channel).join();
+        }
+        else {
+            log.debug("Message only consists of {} embeds [{}]", message.embeds().size(), message.embeds());
+            returnMessage = channel.sendMessage(message.embeds()).join();
+        }
+
+        return returnMessage;
     }
 }

--- a/src/main/java/com/ardaslegends/service/discord/DiscordService.java
+++ b/src/main/java/com/ardaslegends/service/discord/DiscordService.java
@@ -1,0 +1,32 @@
+package com.ardaslegends.service.discord;
+
+import com.ardaslegends.presentation.discord.config.BotProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.permission.Role;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class DiscordService {
+
+
+    private final BotProperties botProperties;
+    private final DiscordApi discordApi;
+
+    public Optional<Role> getRoleById(Long roleId) {
+        log.debug("Getting discord role with id [{}]", roleId);
+        val foundRole = discordApi.getRoleById(roleId);
+
+        if(foundRole.isPresent())
+            log.debug("Found role [{}]", foundRole.get().getName());
+        else
+            log.debug("No role with id [{}] found", roleId);
+        return foundRole;
+    }
+}

--- a/src/main/java/com/ardaslegends/service/discord/messages/ALMessage.java
+++ b/src/main/java/com/ardaslegends/service/discord/messages/ALMessage.java
@@ -4,10 +4,24 @@ import jakarta.validation.constraints.NotNull;
 import org.javacord.api.entity.message.MessageBuilder;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 
-public record ALMessage (MessageBuilder message, @NotNull EmbedBuilder embed) {
+import java.util.List;
+
+public record ALMessage (MessageBuilder message, @NotNull List<EmbedBuilder> embeds) {
+
+    public ALMessage {
+        if(message != null)
+            message.addEmbeds(embeds);
+    }
 
     public boolean hasMessage() {
         return message != null;
     }
 
+    @Override
+    public String toString() {
+        return "ALMessage{" +
+                "message=" + message +
+                ", embeds=" + embeds +
+                '}';
+    }
 }

--- a/src/main/java/com/ardaslegends/service/discord/messages/ALMessage.java
+++ b/src/main/java/com/ardaslegends/service/discord/messages/ALMessage.java
@@ -1,0 +1,13 @@
+package com.ardaslegends.service.discord.messages;
+
+import jakarta.validation.constraints.NotNull;
+import org.javacord.api.entity.message.MessageBuilder;
+import org.javacord.api.entity.message.embed.EmbedBuilder;
+
+public record ALMessage (MessageBuilder message, @NotNull EmbedBuilder embed) {
+
+    public boolean hasMessage() {
+        return message != null;
+    }
+
+}

--- a/src/main/java/com/ardaslegends/service/discord/messages/WarMessages.java
+++ b/src/main/java/com/ardaslegends/service/discord/messages/WarMessages.java
@@ -1,4 +1,0 @@
-package com.ardaslegends.service.discord.messages;
-
-public class WarMessages {
-}

--- a/src/main/java/com/ardaslegends/service/discord/messages/WarMessages.java
+++ b/src/main/java/com/ardaslegends/service/discord/messages/WarMessages.java
@@ -1,0 +1,4 @@
+package com.ardaslegends.service.discord.messages;
+
+public class WarMessages {
+}

--- a/src/main/java/com/ardaslegends/service/discord/messages/war/WarMessages.java
+++ b/src/main/java/com/ardaslegends/service/discord/messages/war/WarMessages.java
@@ -1,0 +1,4 @@
+package com.ardaslegends.service.discord.messages.war;
+
+public class WarMessages {
+}

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -7,13 +7,13 @@ import com.ardaslegends.repository.faction.FactionRepository;
 import com.ardaslegends.repository.player.PlayerRepository;
 import com.ardaslegends.repository.WarRepository;
 import com.ardaslegends.service.AbstractService;
+import com.ardaslegends.service.discord.DiscordService;
 import com.ardaslegends.service.dto.war.CreateWarDto;
 import com.ardaslegends.service.exceptions.logic.faction.FactionServiceException;
 import com.ardaslegends.service.exceptions.logic.player.PlayerServiceException;
 import com.ardaslegends.service.exceptions.logic.war.WarServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.permission.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,7 +34,7 @@ public class WarService extends AbstractService<War, WarRepository> {
     private final WarRepository warRepository;
     private final FactionRepository factionRepository;
     private final PlayerRepository playerRepository;
-    private final DiscordApi discordApi;
+    private final DiscordService discordService;
 
     public Page<War> getWars(Pageable pageable) {
         Objects.requireNonNull(pageable, "Pageable getWarsBody must not be null");
@@ -129,7 +129,7 @@ public class WarService extends AbstractService<War, WarRepository> {
             throw new IllegalArgumentException("CONTACT STAFF -> Faction '%s' does not have a faction role set!".formatted(faction.getName()));
         }
 
-        return discordApi.getRoleById(roleId)
+        return discordService.getRoleById(roleId)
                 .orElseThrow(() -> new IllegalArgumentException("CONTACT STAFF -> Faction '%s' has a broken roleId! [%s]"
                                 .formatted(faction.getName(), faction.getFactionRoleId())));
     }


### PR DESCRIPTION
Added a new `discord` package to the service layer. This package includes the new `DiscordService` class, which provides simple methods for sending messages to specific text channels, for example `sendMessageToClaimbuildAppChannel(ALMessage message)`. Now we have a central way of sending messages to the Discord server on the service layer and we do not need to send messages through commands only anymore.

There is also a `service.discord.messages` package, which will include all the pre-built messages and embeds as static content.
The package also includes a `ALMessage` record class, which is a wrapper for messages we want to send to our channels. An 

`ALMessage` either contains only embeds or a message and additional embeds. If a message is added to the `ALMessage`, the embeds automatically get attached to the message.

`ALMessage` also supports sending multiple embeds in a single message.

Closes #144 