### PR TITLE
Feature#136/end war for staff

### DIFF
--- a/src/main/java/com/ardaslegends/domain/Faction.java
+++ b/src/main/java/com/ardaslegends/domain/Faction.java
@@ -56,9 +56,6 @@ public final class Faction extends AbstractDomainObject {
     @Column(name = "role_id", unique = true)
     private Long factionRoleId; // The roleId of the factionRole so that it can be pinged
 
-    @Transient // Not persisted into DB, only for runtime
-    private Role factionRole;
-
     @OneToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private Region homeRegion; //Homeregion of the faction
 

--- a/src/main/java/com/ardaslegends/domain/war/War.java
+++ b/src/main/java/com/ardaslegends/domain/war/War.java
@@ -44,6 +44,7 @@ public class War extends AbstractDomainObject {
     @NotNull
     private OffsetDateTime startDate;
 
+    @Setter
     private OffsetDateTime endDate;
 
     @Setter

--- a/src/main/java/com/ardaslegends/domain/war/War.java
+++ b/src/main/java/com/ardaslegends/domain/war/War.java
@@ -44,10 +44,10 @@ public class War extends AbstractDomainObject {
     @NotNull
     private OffsetDateTime startDate;
 
-    @Setter
+    @Setter(AccessLevel.PRIVATE)
     private OffsetDateTime endDate;
 
-    @Setter
+    @Setter(AccessLevel.PRIVATE)
     @NotNull
     private Boolean isActive;
 

--- a/src/main/java/com/ardaslegends/domain/war/War.java
+++ b/src/main/java/com/ardaslegends/domain/war/War.java
@@ -133,6 +133,15 @@ public class War extends AbstractDomainObject {
         addToSet(this.battles, battle, WarServiceException.battleAlreadyListed(battle.getName()));
     }
 
+    public void end() {
+        log.debug("Setting war to inactive");
+        setIsActive(false);
+
+        val endDate = OffsetDateTime.now();
+        log.debug("Setting war end date to [{}]", endDate);
+        setEndDate(endDate);
+    }
+
     public Set<WarParticipant> getAggressors() {
         return Collections.unmodifiableSet(this.aggressors);
     }

--- a/src/main/java/com/ardaslegends/domain/war/War.java
+++ b/src/main/java/com/ardaslegends/domain/war/War.java
@@ -46,6 +46,9 @@ public class War extends AbstractDomainObject {
 
     private OffsetDateTime endDate;
 
+    @NotNull
+    private Boolean isActive;
+
     @OneToMany(mappedBy = "war")
     private Set<Battle> battles = new HashSet<>(4);
 
@@ -68,6 +71,7 @@ public class War extends AbstractDomainObject {
         this.defenders.add(defenderWarParticipant);
 
         this.startDate = warDeclarationDate;
+        this.isActive = true;
     }
 
     @NotNull

--- a/src/main/java/com/ardaslegends/domain/war/War.java
+++ b/src/main/java/com/ardaslegends/domain/war/War.java
@@ -134,11 +134,11 @@ public class War extends AbstractDomainObject {
     }
 
     public void end() {
-        log.debug("Setting war to inactive");
+        log.debug("Setting war [{}] to inactive", name);
         setIsActive(false);
 
         val endDate = OffsetDateTime.now();
-        log.debug("Setting war end date to [{}]", endDate);
+        log.debug("Setting war [{}] end date to [{}]",name, endDate);
         setEndDate(endDate);
     }
 

--- a/src/main/java/com/ardaslegends/domain/war/War.java
+++ b/src/main/java/com/ardaslegends/domain/war/War.java
@@ -46,6 +46,7 @@ public class War extends AbstractDomainObject {
 
     private OffsetDateTime endDate;
 
+    @Setter
     @NotNull
     private Boolean isActive;
 

--- a/src/main/java/com/ardaslegends/domain/war/WarParticipant.java
+++ b/src/main/java/com/ardaslegends/domain/war/WarParticipant.java
@@ -45,4 +45,12 @@ public class WarParticipant  {
     public int hashCode() {
         return Objects.hash(warParticipant);
     }
+
+    /**
+     * Returns the name of the war participant faction. Added so you don't have to do .getWarParticipant().getName()
+     * @return The name of the faction
+     */
+    public String getName() {
+       return warParticipant.getName();
+    }
 }

--- a/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -63,9 +64,9 @@ public class WarRestController extends AbstractRestController {
         return ResponseEntity.ok(response);
     }
 
-    //TODO: remove the body as soon as Oauth is done and we have authentication
     @DeleteMapping(FORCE_END)
-    public ResponseEntity<ActiveWarResponse> forceEndWar(@RequestParam EndWarDto dto) {
+    public ResponseEntity<ActiveWarResponse> forceEndWar(String warName, String executorDiscordId) {
+        val dto = new EndWarDto(warName, executorDiscordId);
         log.debug("Incoming force end war Request: Data [{}]", dto);
 
         War createWarResult = wrappedServiceExecution(dto, warService::forceEndWar);

--- a/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
@@ -68,13 +68,12 @@ public class WarRestController extends AbstractRestController {
     public ResponseEntity<ActiveWarResponse> forceEndWar(@RequestParam EndWarDto dto) {
         log.debug("Incoming force end war Request: Data [{}]", dto);
 
-        War createWarResult = wrappedServiceExecution(dto, warService::createWar);
+        War createWarResult = wrappedServiceExecution(dto, warService::forceEndWar);
         ActiveWarResponse response = new ActiveWarResponse(createWarResult);
 
         log.debug("Result from service is [{}]", response);
 
         log.info("Sending successful createWar Request for [{}]", dto.warName());
         return ResponseEntity.ok(response);
-        return null;
     }
 }

--- a/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
@@ -62,17 +62,18 @@ public class WarRestController extends AbstractRestController {
         return ResponseEntity.ok(response);
     }
 
+    //TODO: remove the body as soon as Oauth is done and we have authentication
     @DeleteMapping(FORCE_END)
-    public ResponseEntity<ActiveWarResponse> forceEndWar(@RequestParam String warName, @RequestBody DiscordIdDto dto) {
-        log.debug("Incoming declareWar Request: Data [{}]", dto);
+    public ResponseEntity<ActiveWarResponse> forceEndWar(@RequestParam String warName, @RequestParam DiscordIdDto discordId) {
+        log.debug("Incoming force end war Request: Data [{}]", discordId);
 
-//        War createWarResult = wrappedServiceExecution(dto, warService::createWar);
-//        ActiveWarResponse response = new ActiveWarResponse(createWarResult);
-//
-//        log.debug("Result from service is [{}]", response);
-//
-//        log.info("Sending successful createWar Request for [{}]", dto.nameOfWar());
-//        return ResponseEntity.ok(response);
+        War createWarResult = wrappedServiceExecution(discordId, warService::createWar);
+        ActiveWarResponse response = new ActiveWarResponse(createWarResult);
+
+        log.debug("Result from service is [{}]", response);
+
+        log.info("Sending successful createWar Request for [{}]", discordId.nameOfWar());
+        return ResponseEntity.ok(response);
         return null;
     }
 }

--- a/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
@@ -6,6 +6,7 @@ import com.ardaslegends.presentation.api.response.war.ActiveWarResponse;
 import com.ardaslegends.presentation.api.response.war.PaginatedWarsResponse;
 import com.ardaslegends.service.dto.player.DiscordIdDto;
 import com.ardaslegends.service.dto.war.CreateWarDto;
+import com.ardaslegends.service.dto.war.EndWarDto;
 import com.ardaslegends.service.war.WarService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -64,15 +65,15 @@ public class WarRestController extends AbstractRestController {
 
     //TODO: remove the body as soon as Oauth is done and we have authentication
     @DeleteMapping(FORCE_END)
-    public ResponseEntity<ActiveWarResponse> forceEndWar(@RequestParam String warName, @RequestParam DiscordIdDto discordId) {
-        log.debug("Incoming force end war Request: Data [{}]", discordId);
+    public ResponseEntity<ActiveWarResponse> forceEndWar(@RequestParam EndWarDto dto) {
+        log.debug("Incoming force end war Request: Data [{}]", dto);
 
-        War createWarResult = wrappedServiceExecution(discordId, warService::createWar);
+        War createWarResult = wrappedServiceExecution(dto, warService::createWar);
         ActiveWarResponse response = new ActiveWarResponse(createWarResult);
 
         log.debug("Result from service is [{}]", response);
 
-        log.info("Sending successful createWar Request for [{}]", discordId.nameOfWar());
+        log.info("Sending successful createWar Request for [{}]", dto.warName());
         return ResponseEntity.ok(response);
         return null;
     }

--- a/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/WarRestController.java
@@ -4,6 +4,7 @@ import com.ardaslegends.domain.war.War;
 import com.ardaslegends.presentation.AbstractRestController;
 import com.ardaslegends.presentation.api.response.war.ActiveWarResponse;
 import com.ardaslegends.presentation.api.response.war.PaginatedWarsResponse;
+import com.ardaslegends.service.dto.player.DiscordIdDto;
 import com.ardaslegends.service.dto.war.CreateWarDto;
 import com.ardaslegends.service.war.WarService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,6 +30,8 @@ import java.util.stream.Collectors;
 public class WarRestController extends AbstractRestController {
     public static final String BASE_URL = "/api/wars";
     public static final String CREATE_WAR = "/declare";
+    public static final String END = "/end"; //Will be used later on when faction leaders can end war
+    public static final String FORCE_END = END + "/force"; //Staff only
 
     private final WarService warService;
 
@@ -57,5 +60,19 @@ public class WarRestController extends AbstractRestController {
 
         log.info("Sending successful createWar Request for [{}]", dto.nameOfWar());
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping(FORCE_END)
+    public ResponseEntity<ActiveWarResponse> forceEndWar(@RequestParam String warName, @RequestBody DiscordIdDto dto) {
+        log.debug("Incoming declareWar Request: Data [{}]", dto);
+
+//        War createWarResult = wrappedServiceExecution(dto, warService::createWar);
+//        ActiveWarResponse response = new ActiveWarResponse(createWarResult);
+//
+//        log.debug("Result from service is [{}]", response);
+//
+//        log.info("Sending successful createWar Request for [{}]", dto.nameOfWar());
+//        return ResponseEntity.ok(response);
+        return null;
     }
 }

--- a/src/main/java/com/ardaslegends/presentation/discord/commands/Commands.java
+++ b/src/main/java/com/ardaslegends/presentation/discord/commands/Commands.java
@@ -119,6 +119,22 @@ public class Commands implements DiscordUtils {
                     log.trace("Calling command execution function");
                     response = executions.get(fullname).execute(interaction, options, properties);
 
+                    if(response == null) {
+                        responseUpdater.delete();
+                        return;
+                    }
+
+                    if (response.hasMessage()) {
+                        responseUpdater.delete();
+
+                        response.message()
+                                // TODO Change to war channel
+                                .send(rpCommandsChannel);
+                    }
+                    else {
+                        responseUpdater.addEmbed(response.embed()).update().join();
+                    }
+
                     log.info("Finished handling '/{}' command", fullname);
                 } catch (BotException exception) {
                     log.warn("Encountered ServiceException while executing, msg: {}", exception.getMessage());
@@ -132,20 +148,7 @@ public class Commands implements DiscordUtils {
                     responseUpdater.addEmbed(embed).update().join();
                 }
 
-                if(response == null) {
-                    return;
-                }
 
-                if (response.hasMessage()) {
-                    responseUpdater.delete();
-
-                    response.message()
-                            // TODO Change to war channel
-                            .send(rpCommandsChannel);
-                }
-                else {
-                    responseUpdater.addEmbed(response.embed()).update().join();
-                }
 
                 log.debug("Updating response to new embed");
                 // The join() is important so that the exceptions go into the catch blocks

--- a/src/main/java/com/ardaslegends/presentation/discord/commands/declare/DeclareCommand.java
+++ b/src/main/java/com/ardaslegends/presentation/discord/commands/declare/DeclareCommand.java
@@ -52,7 +52,7 @@ public class DeclareCommand implements ALCommand {
                         .build()
         ));
 
-        commands.put("declare war", new DeclareWarCommand(warService, api)::execute);
+        commands.put("declare war", new DeclareWarCommand(warService)::execute);
         return command;
     }
 }

--- a/src/main/java/com/ardaslegends/presentation/discord/commands/declare/DeclareWarCommand.java
+++ b/src/main/java/com/ardaslegends/presentation/discord/commands/declare/DeclareWarCommand.java
@@ -1,21 +1,14 @@
 package com.ardaslegends.presentation.discord.commands.declare;
 
 
-import com.ardaslegends.domain.Faction;
 import com.ardaslegends.domain.war.War;
 import com.ardaslegends.presentation.discord.commands.ALCommandExecutor;
 import com.ardaslegends.presentation.discord.commands.ALMessageResponse;
 import com.ardaslegends.presentation.discord.config.BotProperties;
-import com.ardaslegends.presentation.discord.utils.ALColor;
 import com.ardaslegends.service.dto.war.CreateWarDto;
 import com.ardaslegends.service.war.WarService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.javacord.api.DiscordApi;
-import org.javacord.api.entity.message.MessageBuilder;
-import org.javacord.api.entity.message.embed.EmbedBuilder;
-import org.javacord.api.entity.message.mention.AllowedMentions;
-import org.javacord.api.entity.message.mention.AllowedMentionsBuilder;
 import org.javacord.api.interaction.SlashCommandInteraction;
 import org.javacord.api.interaction.SlashCommandInteractionOption;
 import org.springframework.stereotype.Component;
@@ -29,7 +22,6 @@ import java.util.List;
 public class DeclareWarCommand implements ALCommandExecutor {
 
     private final WarService warService;
-    private final DiscordApi api;
 
     @Override
     public ALMessageResponse execute(SlashCommandInteraction interaction, List<SlashCommandInteractionOption> options, BotProperties properties) {
@@ -45,42 +37,8 @@ public class DeclareWarCommand implements ALCommandExecutor {
 
         CreateWarDto warDto = new CreateWarDto(executorDiscordId, warName, attackedFactionName);
 
-        War result = discordServiceExecution(warDto, warService::createWar, "Error while declaring war");
+        War war = discordServiceExecution(warDto, warService::createWar, "Error while declaring war");
 
-        Faction attacker = result.getAggressors().stream().findFirst().get().getWarParticipant();
-        Faction defender= result.getDefenders().stream().findFirst().get().getWarParticipant();
-
-        var attackerRole = attacker.getFactionRole();
-        log.debug("Attacker role [{}]", attackerRole);
-        var defenderRole = defender.getFactionRole();
-        log.debug("Defender role [{}]", defenderRole);
-
-        AllowedMentions mentions = new AllowedMentionsBuilder()
-                .setMentionRoles(true)
-                .build();
-
-        MessageBuilder messageBuilder = new MessageBuilder()
-                .setAllowedMentions(mentions)
-                .append(attackerRole.getMentionTag())
-                .append(" declared a War against ")
-                .append(defenderRole.getMentionTag())
-                .append("!");
-
-
-        log.debug("Title: [{}]", warName);
-        log.debug("Attacker Name: [{}]", attacker.getName());
-
-        EmbedBuilder embedBuilder = new EmbedBuilder()
-                .setTitle(warName)
-                .setDescription(messageBuilder.getStringBuilder().toString())
-                .addInlineField("Attacker", attacker.getName())
-                .addInlineField("Defender", defender.getName())
-                .setColor(ALColor.GREEN)
-                .setThumbnail(getFactionBanner(attacker.getName()))
-                .setTimestampToNow();
-
-        messageBuilder.setEmbed(embedBuilder);
-
-        return new ALMessageResponse(messageBuilder, embedBuilder);
+        return null;
     }
 }

--- a/src/main/java/com/ardaslegends/presentation/discord/commands/declare/DeclareWarCommand.java
+++ b/src/main/java/com/ardaslegends/presentation/discord/commands/declare/DeclareWarCommand.java
@@ -62,7 +62,7 @@ public class DeclareWarCommand implements ALCommandExecutor {
         MessageBuilder messageBuilder = new MessageBuilder()
                 .setAllowedMentions(mentions)
                 .append(attackerRole.getMentionTag())
-                .append(" declared a War against")
+                .append(" declared a War against ")
                 .append(defenderRole.getMentionTag())
                 .append("!");
 

--- a/src/main/java/com/ardaslegends/presentation/discord/utils/Thumbnails.java
+++ b/src/main/java/com/ardaslegends/presentation/discord/utils/Thumbnails.java
@@ -5,6 +5,7 @@ public enum Thumbnails {
     MOVE_CHARACTER("https://cdn.discordapp.com/attachments/993179687956258867/993202523475292290/move_character.jpg"),
     INJURE_CHARACTER("https://cdn.discordapp.com/attachments/1022950091214041108/1022951678598721597/unknown.png"),
     HEAL("https://cdn.discordapp.com/attachments/993179687956258867/993202461743517766/heal.jpg"),
+    END_WAR("https://cdn.discordapp.com/attachments/993179687956258867/993202619281588355/peace.jpg"),
     BIND_TRADER("https://cdn.discordapp.com/attachments/993179687956258867/993202395913916416/create_trader.jpeg");
 
     private final String url;

--- a/src/main/java/com/ardaslegends/repository/WarRepository.java
+++ b/src/main/java/com/ardaslegends/repository/WarRepository.java
@@ -2,17 +2,10 @@ package com.ardaslegends.repository;
 
 import com.ardaslegends.domain.Faction;
 import com.ardaslegends.domain.war.War;
-import com.ardaslegends.presentation.api.WarRestController;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -24,9 +17,10 @@ public interface WarRepository extends JpaRepository<War, Long> {
             select w from War w 
                 left join w.aggressors aggressors 
                 left join w.defenders defenders
-            where aggressors.warParticipant = ?1
-            or defenders.warParticipant = ?1""")
-    Set<War> findAllWarsWithFaction(Faction faction);
+            where (aggressors.warParticipant = ?1
+            or defenders.warParticipant = ?1)
+            and isActive = true""")
+    Set<War> findAllActiveWarsWithFaction(Faction faction);
 
     @Query("""
             select (count(w) > 0) from War w 

--- a/src/main/java/com/ardaslegends/repository/WarRepository.java
+++ b/src/main/java/com/ardaslegends/repository/WarRepository.java
@@ -32,8 +32,10 @@ public interface WarRepository extends JpaRepository<War, Long> {
             select (count(w) > 0) from War w 
                 left join w.aggressors aggressors 
                 left join w.defenders defenders
-            where (aggressors.warParticipant = ?1 and defenders.warParticipant = ?2)
-            or (aggressors.warParticipant = ?2 and defenders.warParticipant = ?1)""")
+            where ((aggressors.warParticipant = ?1 and defenders.warParticipant = ?2)
+            or (aggressors.warParticipant = ?2 and defenders.warParticipant = ?1))
+            and (isActive = true)
+            and (endDate is null)""")
     boolean isFactionAtWarWithOtherFaction(Faction faction, Faction otherFaction);
 
 }

--- a/src/main/java/com/ardaslegends/repository/exceptions/NotFoundException.java
+++ b/src/main/java/com/ardaslegends/repository/exceptions/NotFoundException.java
@@ -3,7 +3,7 @@ package com.ardaslegends.repository.exceptions;
 public class NotFoundException extends DataAccessException{
 
 
-    private final String GENERIC_COULD_NOT_FIND = "Could not find %s with %s %s!";
+    private static final String GENERIC_COULD_NOT_FIND = "Could not find %s with %s %s!";
 
     protected NotFoundException(String message) {
         super(message);
@@ -11,6 +11,13 @@ public class NotFoundException extends DataAccessException{
 
     protected NotFoundException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    /**
+     * Results in an error with format "Could not find %s with %s %s!"
+     */
+    public static NotFoundException genericNotFound(String couldNotFind, String with, String value) {
+        return new NotFoundException(GENERIC_COULD_NOT_FIND.formatted(couldNotFind, with, value));
     }
 
 }

--- a/src/main/java/com/ardaslegends/repository/exceptions/NotFoundException.java
+++ b/src/main/java/com/ardaslegends/repository/exceptions/NotFoundException.java
@@ -1,9 +1,12 @@
 package com.ardaslegends.repository.exceptions;
 
+import com.ardaslegends.service.exceptions.logic.war.WarServiceException;
+
 public class NotFoundException extends DataAccessException{
 
 
     private static final String GENERIC_COULD_NOT_FIND = "Could not find %s with %s %s!";
+    private static final String NO_WAR_WITH_NAME = "No war with name '%s' found!";
 
     protected NotFoundException(String message) {
         super(message);
@@ -19,5 +22,7 @@ public class NotFoundException extends DataAccessException{
     public static NotFoundException genericNotFound(String couldNotFind, String with, String value) {
         return new NotFoundException(GENERIC_COULD_NOT_FIND.formatted(couldNotFind, with, value));
     }
+    public static NotFoundException noWarWithNameFound(String name) {return new NotFoundException(NO_WAR_WITH_NAME.formatted(name));}
+
 
 }

--- a/src/main/java/com/ardaslegends/service/Pathfinder.java
+++ b/src/main/java/com/ardaslegends/service/Pathfinder.java
@@ -39,7 +39,7 @@ public class Pathfinder {
             throw PathfinderServiceException.alreadyInRegion();
         }
 
-        var wars = warService.getWarsOfFaction(player.getFaction());
+        var wars = warService.getActiveWarsOfFaction(player.getFaction());
 
         log.debug("Initializing data for Pathfinding...");
         //smallest weights between startRegion and all the other nodes

--- a/src/main/java/com/ardaslegends/service/discord/DiscordService.java
+++ b/src/main/java/com/ardaslegends/service/discord/DiscordService.java
@@ -3,6 +3,7 @@ package com.ardaslegends.service.discord;
 import com.ardaslegends.domain.Faction;
 import com.ardaslegends.presentation.discord.commands.ALMessageResponse;
 import com.ardaslegends.presentation.discord.config.BotProperties;
+import com.ardaslegends.repository.exceptions.NotFoundException;
 import com.ardaslegends.service.discord.messages.ALMessage;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,23 @@ public class DiscordService {
         else
             log.debug("No role with id [{}] found", roleId);
         return foundRole;
+    }
+
+    /**
+     * The same as getRoleById() but throws an exception when the role was not found
+     * @param roleId
+     * @throws NotFoundException
+     * @return the found discord role
+     */
+    public Role getRoleByIdOrElseThrow(Long roleId) {
+        log.debug("Getting discord role with id [{}]", roleId);
+        val foundRole = discordApi.getRoleById(roleId);
+
+        if(foundRole.isEmpty()) {
+            log.warn("Could not find discord role [{}]", roleId);
+            throw NotFoundException.genericNotFound("discord role", "id", roleId.toString());
+        }
+        return foundRole.get();
     }
 
     public User getUserById(String discordId) {

--- a/src/main/java/com/ardaslegends/service/discord/DiscordService.java
+++ b/src/main/java/com/ardaslegends/service/discord/DiscordService.java
@@ -1,8 +1,10 @@
 package com.ardaslegends.service.discord;
 
+import com.ardaslegends.domain.Faction;
 import com.ardaslegends.presentation.discord.commands.ALMessageResponse;
 import com.ardaslegends.presentation.discord.config.BotProperties;
 import com.ardaslegends.service.discord.messages.ALMessage;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -73,5 +75,17 @@ public class DiscordService {
         }
 
         return returnMessage;
+    }
+
+    public Role fetchFactionRole(@NotNull Faction faction) {
+        Long roleId = faction.getFactionRoleId();
+
+        if(roleId == null) {
+            throw new IllegalArgumentException("CONTACT STAFF -> Faction '%s' does not have a faction role set!".formatted(faction.getName()));
+        }
+
+        return getRoleById(roleId)
+                .orElseThrow(() -> new IllegalArgumentException("CONTACT STAFF -> Faction '%s' has a broken roleId! [%s]"
+                        .formatted(faction.getName(), faction.getFactionRoleId())));
     }
 }

--- a/src/main/java/com/ardaslegends/service/discord/DiscordService.java
+++ b/src/main/java/com/ardaslegends/service/discord/DiscordService.java
@@ -94,16 +94,4 @@ public class DiscordService {
 
         return returnMessage;
     }
-
-    public Role fetchFactionRole(@NotNull Faction faction) {
-        Long roleId = faction.getFactionRoleId();
-
-        if(roleId == null) {
-            throw new IllegalArgumentException("CONTACT STAFF -> Faction '%s' does not have a faction role set!".formatted(faction.getName()));
-        }
-
-        return getRoleById(roleId)
-                .orElseThrow(() -> new IllegalArgumentException("CONTACT STAFF -> Faction '%s' has a broken roleId! [%s]"
-                        .formatted(faction.getName(), faction.getFactionRoleId())));
-    }
 }

--- a/src/main/java/com/ardaslegends/service/discord/DiscordService.java
+++ b/src/main/java/com/ardaslegends/service/discord/DiscordService.java
@@ -10,6 +10,7 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.permission.Role;
+import org.javacord.api.entity.user.User;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
@@ -33,6 +34,11 @@ public class DiscordService {
         else
             log.debug("No role with id [{}] found", roleId);
         return foundRole;
+    }
+
+    public User getUserById(String discordId) {
+        log.debug("Getting discord user with id [{}]", discordId);
+        return discordApi.getUserById(discordId).join();
     }
 
     public Message sendMessageToRpChannel(ALMessage message) {

--- a/src/main/java/com/ardaslegends/service/discord/messages/war/WarMessages.java
+++ b/src/main/java/com/ardaslegends/service/discord/messages/war/WarMessages.java
@@ -1,6 +1,5 @@
 package com.ardaslegends.service.discord.messages.war;
 
-import com.ardaslegends.domain.Faction;
 import com.ardaslegends.domain.Player;
 import com.ardaslegends.domain.war.War;
 import com.ardaslegends.domain.war.WarParticipant;
@@ -14,14 +13,16 @@ import org.javacord.api.entity.message.MessageBuilder;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.message.mention.AllowedMentions;
 import org.javacord.api.entity.message.mention.AllowedMentionsBuilder;
-import org.javacord.api.entity.user.User;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class WarMessages {
 
     public static ALMessage declareWar(War war, DiscordService discordService) {
+        Objects.requireNonNull(war, "Declare war error discord message got passed null value for war");
+        Objects.requireNonNull(discordService, "Declare war error discord message got passed null value for discordService");
 
         val attacker = war.getInitialAttacker().getWarParticipant();
         val defender = war.getInitialDefender().getWarParticipant();
@@ -54,6 +55,10 @@ public class WarMessages {
     }
 
     public static ALMessage forceEndWar(War war, Player warEndedByPlayer, DiscordService discordService) {
+        Objects.requireNonNull(war, "Force end war error discord message got passed null value for war");
+        Objects.requireNonNull(warEndedByPlayer, "Force end war error discord message got passed null value for player that ended war");
+        Objects.requireNonNull(discordService, "Force end war error discord message got passed null value for discordService");
+
         AllowedMentions mentions = new AllowedMentionsBuilder()
                 .setMentionRoles(true)
                 .build();

--- a/src/main/java/com/ardaslegends/service/discord/messages/war/WarMessages.java
+++ b/src/main/java/com/ardaslegends/service/discord/messages/war/WarMessages.java
@@ -1,4 +1,52 @@
 package com.ardaslegends.service.discord.messages.war;
 
+import com.ardaslegends.domain.Player;
+import com.ardaslegends.domain.war.War;
+import com.ardaslegends.domain.war.WarParticipant;
+import com.ardaslegends.presentation.discord.utils.ALColor;
+import com.ardaslegends.presentation.discord.utils.FactionBanners;
+import com.ardaslegends.presentation.discord.utils.Thumbnails;
+import com.ardaslegends.service.discord.messages.ALMessage;
+import lombok.val;
+import org.javacord.api.entity.message.MessageBuilder;
+import org.javacord.api.entity.message.embed.EmbedBuilder;
+import org.javacord.api.entity.message.mention.AllowedMentions;
+import org.javacord.api.entity.message.mention.AllowedMentionsBuilder;
+import org.javacord.api.entity.user.User;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class WarMessages {
+
+    public static ALMessage forceEndWar(War war, User warEndedBy) {
+        AllowedMentions mentions = new AllowedMentionsBuilder()
+                .setMentionRoles(true)
+                .build();
+
+        val attackerRole = war.getInitialAttacker().getWarParticipant().getFactionRole();
+        val defenderRole = war.getInitialDefender().getWarParticipant().getFactionRole();
+
+        val message = new MessageBuilder()
+                .setAllowedMentions(mentions)
+                .append("The war between ")
+                .append(attackerRole.getMentionTag())
+                .append(" and ")
+                .append(defenderRole.getMentionTag())
+                .append(" was ended by ")
+                .append(warEndedBy.getMentionTag())
+                .append("!");
+
+        val embed = new EmbedBuilder()
+                .setTitle(war.getName() + " was ended by staff!")
+                .setColor(ALColor.YELLOW)
+                .setDescription("The attacking war of %s against %s was ended by staff member %s!".formatted(attackerRole.getMentionTag(), defenderRole.getMentionTag(), warEndedBy.getMentionTag()))
+                .addInlineField("Attackers", war.getAggressors().stream().map(WarParticipant::getName).collect(Collectors.joining("\n")))
+                .addInlineField("Defenders", war.getDefenders().stream().map(WarParticipant::getName).collect(Collectors.joining("\n")))
+                .addField("War ended by", warEndedBy.getMentionTag())
+                .setThumbnail(Thumbnails.END_WAR.getUrl())
+                .setTimestampToNow();
+
+        return new ALMessage(message, List.of(embed));
+    }
 }

--- a/src/main/java/com/ardaslegends/service/discord/messages/war/WarMessages.java
+++ b/src/main/java/com/ardaslegends/service/discord/messages/war/WarMessages.java
@@ -1,5 +1,6 @@
 package com.ardaslegends.service.discord.messages.war;
 
+import com.ardaslegends.domain.Faction;
 import com.ardaslegends.domain.Player;
 import com.ardaslegends.domain.war.War;
 import com.ardaslegends.domain.war.WarParticipant;
@@ -19,6 +20,38 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class WarMessages {
+
+    public static ALMessage declareWar(War war, DiscordService discordService) {
+
+        val attacker = war.getInitialAttacker().getWarParticipant();
+        val defender = war.getInitialDefender().getWarParticipant();
+
+        val attackerRole = discordService.getRoleByIdOrElseThrow(attacker.getFactionRoleId());
+        val defenderRole = discordService.getRoleByIdOrElseThrow(defender.getFactionRoleId());
+
+        AllowedMentions mentions = new AllowedMentionsBuilder()
+                .setMentionRoles(true)
+                .build();
+
+        MessageBuilder message = new MessageBuilder()
+                .setAllowedMentions(mentions)
+                .append(attackerRole.getMentionTag())
+                .append(" declared a War against ")
+                .append(defenderRole.getMentionTag())
+                .append("!");
+
+
+        EmbedBuilder embed = new EmbedBuilder()
+                .setTitle(war.getName())
+                .setDescription(message.getStringBuilder().toString())
+                .addInlineField("Attacker", attacker.getName())
+                .addInlineField("Defender", defender.getName())
+                .setColor(ALColor.GREEN)
+                .setThumbnail(FactionBanners.getBannerUrl(attacker.getName()))
+                .setTimestampToNow();
+
+        return new ALMessage(message, List.of(embed));
+    }
 
     public static ALMessage forceEndWar(War war, Player warEndedByPlayer, DiscordService discordService) {
         AllowedMentions mentions = new AllowedMentionsBuilder()

--- a/src/main/java/com/ardaslegends/service/dto/war/EndWarDto.java
+++ b/src/main/java/com/ardaslegends/service/dto/war/EndWarDto.java
@@ -1,0 +1,4 @@
+package com.ardaslegends.service.dto.war;
+
+public record EndWarDto(String warName, String executorDiscordId) {
+}

--- a/src/main/java/com/ardaslegends/service/exceptions/logic/war/WarServiceException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/logic/war/WarServiceException.java
@@ -1,6 +1,7 @@
 package com.ardaslegends.service.exceptions.logic.war;
 
 import com.ardaslegends.service.exceptions.logic.LogicException;
+import com.ardaslegends.service.war.WarService;
 
 public class WarServiceException extends LogicException {
 
@@ -11,6 +12,7 @@ public class WarServiceException extends LogicException {
     private static final String CANNOT_DECLARE_WAR_ON_YOUR_FACTION = "You cannot declare war on your own faction!";
     private static final String ALREADY_AT_WAR = "Your faction '%s' is already at war with '%s'!";
     private static final String NO_WAR_WITH_NAME = "No war with name '%s' found!";
+    private static final String WAR_NOT_ACTIVE = "The war '%s' is already over!";
 
     public static WarServiceException noWarDeclarationPermissions() { return new WarServiceException(NO_WAR_DECLARATION_PERMISSIONS); }
     public static WarServiceException factionAlreadyJoinedTheWarAsAttacker(String factionName) { return new WarServiceException(FACTION_ALREADY_JOINED_THE_WAR_AS_ATTACKER.formatted(factionName));}
@@ -19,6 +21,7 @@ public class WarServiceException extends LogicException {
     public static WarServiceException cannotDeclareWarOnYourFaction() { return new WarServiceException(CANNOT_DECLARE_WAR_ON_YOUR_FACTION); }
     public static WarServiceException alreadyAtWar(String executorFaction, String otherFaction) { return new WarServiceException(ALREADY_AT_WAR.formatted(executorFaction, otherFaction)); }
     public static WarServiceException noWarWithNameFound(String name) {return new WarServiceException(NO_WAR_WITH_NAME.formatted(name));}
+    public static WarServiceException warNotActive(String name) {return new WarServiceException(WAR_NOT_ACTIVE.formatted(name));}
 
     public WarServiceException(String message, Throwable rootCause) {
         super(message, rootCause);

--- a/src/main/java/com/ardaslegends/service/exceptions/logic/war/WarServiceException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/logic/war/WarServiceException.java
@@ -11,7 +11,6 @@ public class WarServiceException extends LogicException {
     private static final String THIS_BATTLE_IS_ALREADY_IN_THE_BATTLE_LIST = "Battle [%s] is already listed in the battles of this war";
     private static final String CANNOT_DECLARE_WAR_ON_YOUR_FACTION = "You cannot declare war on your own faction!";
     private static final String ALREADY_AT_WAR = "Your faction '%s' is already at war with '%s'!";
-    private static final String NO_WAR_WITH_NAME = "No war with name '%s' found!";
     private static final String WAR_NOT_ACTIVE = "The war '%s' is already over!";
 
     public static WarServiceException noWarDeclarationPermissions() { return new WarServiceException(NO_WAR_DECLARATION_PERMISSIONS); }
@@ -20,7 +19,6 @@ public class WarServiceException extends LogicException {
     public static WarServiceException battleAlreadyListed(String battleName) { return new WarServiceException(THIS_BATTLE_IS_ALREADY_IN_THE_BATTLE_LIST.formatted(battleName));}
     public static WarServiceException cannotDeclareWarOnYourFaction() { return new WarServiceException(CANNOT_DECLARE_WAR_ON_YOUR_FACTION); }
     public static WarServiceException alreadyAtWar(String executorFaction, String otherFaction) { return new WarServiceException(ALREADY_AT_WAR.formatted(executorFaction, otherFaction)); }
-    public static WarServiceException noWarWithNameFound(String name) {return new WarServiceException(NO_WAR_WITH_NAME.formatted(name));}
     public static WarServiceException warNotActive(String name) {return new WarServiceException(WAR_NOT_ACTIVE.formatted(name));}
 
     public WarServiceException(String message, Throwable rootCause) {

--- a/src/main/java/com/ardaslegends/service/exceptions/logic/war/WarServiceException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/logic/war/WarServiceException.java
@@ -10,6 +10,7 @@ public class WarServiceException extends LogicException {
     private static final String THIS_BATTLE_IS_ALREADY_IN_THE_BATTLE_LIST = "Battle [%s] is already listed in the battles of this war";
     private static final String CANNOT_DECLARE_WAR_ON_YOUR_FACTION = "You cannot declare war on your own faction!";
     private static final String ALREADY_AT_WAR = "Your faction '%s' is already at war with '%s'!";
+    private static final String NO_WAR_WITH_NAME = "No war with name '%s' found!";
 
     public static WarServiceException noWarDeclarationPermissions() { return new WarServiceException(NO_WAR_DECLARATION_PERMISSIONS); }
     public static WarServiceException factionAlreadyJoinedTheWarAsAttacker(String factionName) { return new WarServiceException(FACTION_ALREADY_JOINED_THE_WAR_AS_ATTACKER.formatted(factionName));}
@@ -17,6 +18,7 @@ public class WarServiceException extends LogicException {
     public static WarServiceException battleAlreadyListed(String battleName) { return new WarServiceException(THIS_BATTLE_IS_ALREADY_IN_THE_BATTLE_LIST.formatted(battleName));}
     public static WarServiceException cannotDeclareWarOnYourFaction() { return new WarServiceException(CANNOT_DECLARE_WAR_ON_YOUR_FACTION); }
     public static WarServiceException alreadyAtWar(String executorFaction, String otherFaction) { return new WarServiceException(ALREADY_AT_WAR.formatted(executorFaction, otherFaction)); }
+    public static WarServiceException noWarWithNameFound(String name) {return new WarServiceException(NO_WAR_WITH_NAME.formatted(name));}
 
     public WarServiceException(String message, Throwable rootCause) {
         super(message, rootCause);

--- a/src/main/java/com/ardaslegends/service/exceptions/permission/StaffPermissionException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/permission/StaffPermissionException.java
@@ -1,6 +1,8 @@
 package com.ardaslegends.service.exceptions.permission;
 
 public class StaffPermissionException extends PermissionException{
+
+    private static final String NO_STAFF_PERMISSION = "Only staff members can perform this action!";
     protected StaffPermissionException(String message, Throwable rootCause) {
         super(message, rootCause);
     }
@@ -8,4 +10,6 @@ public class StaffPermissionException extends PermissionException{
     protected StaffPermissionException(String message) {
         super(message);
     }
+
+    public static StaffPermissionException noStaffPermission() {return new StaffPermissionException(NO_STAFF_PERMISSION);}
 }

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -150,12 +150,8 @@ public class WarService extends AbstractService<War, WarRepository> {
         val war = getWarByName(dto.warName());
         log.debug("Found war with name [{}]", war.getName());
 
-        log.debug("Setting war to inactive");
-        war.setIsActive(false);
-
-        val endDate = OffsetDateTime.now();
-        log.debug("Setting war end date to [{}]", endDate);
-        war.setEndDate(endDate);
+        log.debug("Ending war");
+        war.end();
 
         discordService.sendMessageToRpChannel(WarMessages.forceEndWar(war, player, discordService));
 

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -106,6 +106,8 @@ public class WarService extends AbstractService<War, WarRepository> {
         log.debug("Saving War Entity");
         war = secureSave(war, warRepository);
 
+        discordService.sendMessageToRpChannel(WarMessages.declareWar(war, discordService));
+
         log.info("Successfully executed and saved new war {}", war.getName());
         return war;
     }

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -147,7 +147,7 @@ public class WarService extends AbstractService<War, WarRepository> {
             throw StaffPermissionException.noStaffPermission();
         }
 
-        val war = getWarByName(dto.warName());
+        val war = getActiveWarByName(dto.warName());
         log.debug("Found war with name [{}]", war.getName());
 
         log.debug("Ending war");
@@ -174,7 +174,20 @@ public class WarService extends AbstractService<War, WarRepository> {
         }
         val war = foundWar.get();
 
-        log.info("Found war [{}] between attacker [{}] and defender [{}]", war.getName(), war.getInitialAttacker().getWarParticipant().getName(), war.getInitialDefender().getWarParticipant().getName());
+        log.debug("Found war [{}] between attacker [{}] and defender [{}]", war.getName(), war.getInitialAttacker().getWarParticipant().getName(), war.getInitialDefender().getWarParticipant().getName());
+        return war;
+    }
+
+    public War getActiveWarByName(String name) {
+        log.debug("Getting active war with name [{}]", name);
+        val war = getWarByName(name);
+
+        if(!war.getIsActive()) {
+            log.warn("War [{}] is not active!", name);
+            throw WarServiceException.warNotActive(name);
+        }
+
+        log.info("Found active war [{}] between attacker [{}] and defender [{}]", war.getName(), war.getInitialAttacker().getWarParticipant().getName(), war.getInitialDefender().getWarParticipant().getName());
         return war;
     }
 

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -153,7 +153,7 @@ public class WarService extends AbstractService<War, WarRepository> {
         ServiceUtils.checkBlankString(name, "name");
 
         log.debug("Fetching war with name [{}]", name);
-        val foundWar = warRepository.findByName(name);
+        val foundWar = secureFind(name, warRepository::findByName);
 
         if(foundWar.isEmpty()) {
             log.warn("Found no war with name [{}]", name);

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -101,14 +101,6 @@ public class WarService extends AbstractService<War, WarRepository> {
             throw WarServiceException.alreadyAtWar(attackingFaction.getName(), defendingFaction.getName());
         }
 
-        // Get Roles
-        if(attackingFaction.getFactionRole() == null) {
-            attackingFaction.setFactionRole(fetchFactionRole(attackingFaction));
-        }
-        if(defendingFaction.getFactionRole() == null) {
-            defendingFaction.setFactionRole(fetchFactionRole(defendingFaction));
-        }
-
         War war = new War(createWarDto.nameOfWar(), attackingFaction, defendingFaction);
 
         log.debug("Saving War Entity");
@@ -163,20 +155,7 @@ public class WarService extends AbstractService<War, WarRepository> {
         log.debug("Setting war end date to [{}]", endDate);
         war.setEndDate(endDate);
 
-        war.getAggressors().forEach(attacker -> {
-            if(attacker.getWarParticipant().getFactionRole() == null) {
-                attacker.getWarParticipant().setFactionRole(fetchFactionRole(attacker.getWarParticipant()));
-            }
-        });
-
-        war.getDefenders().forEach(defender -> {
-            if(defender.getWarParticipant().getFactionRole() == null) {
-                defender.getWarParticipant().setFactionRole(fetchFactionRole(defender.getWarParticipant()));
-            }
-        });
-
-        val staffDiscordUser = discordService.getUserById(player.getDiscordID());
-        discordService.sendMessageToRpChannel(WarMessages.forceEndWar(war, staffDiscordUser));
+        discordService.sendMessageToRpChannel(WarMessages.forceEndWar(war, player, discordService));
 
         log.info("War [{}] between attacker [{}] and defender [{}] has succesfully been ended by staff member [{}]", war.getName(), war.getInitialAttacker().getName(), war.getInitialDefender().getName(), player.getIgn());
         return war;

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -3,6 +3,7 @@ package com.ardaslegends.service.war;
 import com.ardaslegends.domain.Faction;
 import com.ardaslegends.domain.Player;
 import com.ardaslegends.domain.war.War;
+import com.ardaslegends.repository.exceptions.NotFoundException;
 import com.ardaslegends.repository.faction.FactionRepository;
 import com.ardaslegends.repository.player.PlayerRepository;
 import com.ardaslegends.repository.WarRepository;
@@ -168,7 +169,7 @@ public class WarService extends AbstractService<War, WarRepository> {
 
         if(foundWar.isEmpty()) {
             log.warn("Found no war with name [{}]", name);
-            throw WarServiceException.noWarWithNameFound(name);
+            throw NotFoundException.noWarWithNameFound(name);
         }
         val war = foundWar.get();
 

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -201,16 +201,4 @@ public class WarService extends AbstractService<War, WarRepository> {
         return war;
     }
 
-    private Role fetchFactionRole(Faction faction) {
-        Long roleId = faction.getFactionRoleId();
-
-        if(roleId == null) {
-            throw new IllegalArgumentException("CONTACT STAFF -> Faction '%s' does not have a faction role set!".formatted(faction.getName()));
-        }
-
-        return discordService.getRoleById(roleId)
-                .orElseThrow(() -> new IllegalArgumentException("CONTACT STAFF -> Faction '%s' has a broken roleId! [%s]"
-                                .formatted(faction.getName(), faction.getFactionRoleId())));
-    }
-
 }

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -19,13 +19,11 @@ import com.ardaslegends.service.utils.ServiceUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.javacord.api.entity.permission.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -112,13 +110,13 @@ public class WarService extends AbstractService<War, WarRepository> {
         return war;
     }
 
-    public Set<War> getWarsOfFaction(String factionName) {
+    public Set<War> getActiveWarsOfFaction(String factionName) {
         // TODO, not yet implemented
         return null;
     }
 
-    public Set<War> getWarsOfFaction(Faction faction) {
-        Set<War> wars = secureFind(faction, warRepository::findAllWarsWithFaction);
+    public Set<War> getActiveWarsOfFaction(Faction faction) {
+        Set<War> wars = secureFind(faction, warRepository::findAllActiveWarsWithFaction);
         return wars;
     }
 


### PR DESCRIPTION
Added functionality for staff members to end wars. Ending a war will result in the `isActive` flag to be set to `false` as well as the `endDate` being set.

New functionality:
- New REST endpoint `/api/wars/end/force` with HTTP DELETE mapping
- New `WarService` method `forceEndWar()`.
    - Ends a war if the `warName` could be associated with an active war and the executor is a staff member
- Added a `WarMessage` for `forceEndWar`
- Added a `WarMessage` for `declareWar`

Refactor:
- Removed `factionRole` from `Faction` class because it was useless
- Removed the embed and message being built inside the `DeclareWarCommand` and moved it to `WarService/createWar`
- Refactored the `Command` class so we can have commands that do not return a message
- Refactored all the currently used `WarRepository` queries to only return active wars

Closes #136 