### PR TITLE
Feature#158/create battle missing features

### DIFF
--- a/src/main/java/com/ardaslegends/domain/Army.java
+++ b/src/main/java/com/ardaslegends/domain/Army.java
@@ -151,4 +151,8 @@ public final class Army extends AbstractDomainObject {
         this.setHoursHealed(0);
         this.setHoursLeftHealing(0);
     }
+
+    public boolean isYoungerThan24h() {
+        return OffsetDateTime.now().isBefore(this.createdAt.plusHours(24));
+    }
 }

--- a/src/main/java/com/ardaslegends/presentation/api/BattleRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/BattleRestController.java
@@ -1,9 +1,17 @@
 package com.ardaslegends.presentation.api;
 
+import com.ardaslegends.domain.war.Battle;
+import com.ardaslegends.presentation.api.response.war.BattleResponse;
+import com.ardaslegends.service.dto.war.CreateBattleDto;
 import com.ardaslegends.service.war.BattleService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,4 +26,18 @@ public class BattleRestController {
 
     private final BattleService battleService;
 
+    @Operation(summary = "Declare Battle", description = "Declare a battle on an army or claimbuild")
+    @PostMapping
+    public ResponseEntity<BattleResponse> createBattle(@RequestBody CreateBattleDto dto) {
+        log.debug("Incoming createBattle Request, dto [{}]", dto);
+
+        log.debug("Calling battleService.createBattle");
+        Battle battle = battleService.createBattle(dto);
+
+        log.debug("Building response");
+        val battleResponse = new BattleResponse(battle);
+
+        log.info("Sending successful createBattle response [{}]", battleResponse);
+        return ResponseEntity.ok(battleResponse);
+    }
 }

--- a/src/main/java/com/ardaslegends/presentation/api/BattleRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/BattleRestController.java
@@ -1,0 +1,21 @@
+package com.ardaslegends.presentation.api;
+
+import com.ardaslegends.service.war.BattleService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+
+@Slf4j
+@RestController
+@Tag(name = "Battle Controller", description = "REST endpoints concerning Battles")
+@RequestMapping(BattleRestController.BASE_URL)
+public class BattleRestController {
+    public static final String BASE_URL = "/api/battles";
+
+    private final BattleService battleService;
+
+}

--- a/src/main/java/com/ardaslegends/presentation/api/response/war/BattleArmyResponse.java
+++ b/src/main/java/com/ardaslegends/presentation/api/response/war/BattleArmyResponse.java
@@ -11,7 +11,7 @@ public record BattleArmyResponse(
         this(
                 army.getName(),
                 army.getFaction().getName(),
-                army.getBoundTo().getOwner().getIgn()
+                army.getBoundTo() == null ? null : army.getBoundTo().getOwner().getIgn()
         );
     }
 }

--- a/src/main/java/com/ardaslegends/service/MovementService.java
+++ b/src/main/java/com/ardaslegends/service/MovementService.java
@@ -92,7 +92,7 @@ public class MovementService extends AbstractService<Movement, MovementRepositor
         }
 
         log.debug("Checking if army is older than 24h");
-        if(OffsetDateTime.now().isBefore(army.getCreatedAt().plusDays(1))) {
+        if(army.isYoungerThan24h()) {
             log.warn("Army [{}] is younger than 24h and therefore cannot move!", army);
             long hoursUntilMove = 24 - Duration.between(army.getCreatedAt(), OffsetDateTime.now()).toHours();
             log.debug("Army can move again in [{}] hours", hoursUntilMove);

--- a/src/main/java/com/ardaslegends/service/exceptions/logic/war/BattleServiceException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/logic/war/BattleServiceException.java
@@ -13,6 +13,7 @@ public class BattleServiceException extends LogicException {
     private static final String ATTACKING_ARMY_HAS_ANOTHER_MOVEMENT = "Attacking army has another ongoing movement!";
     private static final String CANNOT_ATTACK_STARTER_HAMLET = "Starter hamlets cannot be attacked!";
     private static final String NO_PLAYER_BOUND = "The army '%s' must have a player bound to it in order to attack!";
+    private static final String ARMY_YOUNGER_THAN_24H = "The army '%s' was created less than 24 hours ago!";
 
     public static BattleServiceException factionsNotAtWar(String factionName1, String factionName2) { return new BattleServiceException(FACTIONS_NOT_AT_WAR.formatted(factionName1, factionName2)); }
 
@@ -25,6 +26,7 @@ public class BattleServiceException extends LogicException {
     public static BattleServiceException notInSameRegion(Army attacker, Army defender){ return new BattleServiceException(NOT_IN_SAME_REGION.formatted(defender.getName(), attacker.getName()));}
     public static BattleServiceException cannotAttackStarterHamlet() {return new BattleServiceException(CANNOT_ATTACK_STARTER_HAMLET);}
     public static BattleServiceException noPlayerBound(String armyName) {return new BattleServiceException(NO_PLAYER_BOUND.formatted(armyName));}
+    public static BattleServiceException armyYoungerThan24h(String armyName) {return new BattleServiceException(ARMY_YOUNGER_THAN_24H.formatted(armyName));}
     protected BattleServiceException(String message, Throwable rootCause) {
         super(message, rootCause);
     }

--- a/src/main/java/com/ardaslegends/service/exceptions/logic/war/BattleServiceException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/logic/war/BattleServiceException.java
@@ -2,6 +2,7 @@ package com.ardaslegends.service.exceptions.logic.war;
 
 import com.ardaslegends.domain.Army;
 import com.ardaslegends.service.exceptions.logic.LogicException;
+import com.ardaslegends.service.war.BattleService;
 
 public class BattleServiceException extends LogicException {
     private static final String FACTIONS_NOT_AT_WAR = "Cannot declare a battle because %s and %s are not at war with each other!";
@@ -11,6 +12,7 @@ public class BattleServiceException extends LogicException {
     private static final String NOT_IN_SAME_REGION = "The army you are trying to attack (%s) is not in the same region as your army (%s)!";
     private static final String ATTACKING_ARMY_HAS_ANOTHER_MOVEMENT = "Attacking army has another ongoing movement!";
     private static final String CANNOT_ATTACK_STARTER_HAMLET = "Starter hamlets cannot be attacked!";
+    private static final String NO_PLAYER_BOUND = "The army '%s' must have a player bound to it in order to attack!";
 
     public static BattleServiceException factionsNotAtWar(String factionName1, String factionName2) { return new BattleServiceException(FACTIONS_NOT_AT_WAR.formatted(factionName1, factionName2)); }
 
@@ -22,6 +24,7 @@ public class BattleServiceException extends LogicException {
     public static BattleServiceException notEnoughHealth(){ return new BattleServiceException(NOT_ENOUGH_HEALTH.formatted());}
     public static BattleServiceException notInSameRegion(Army attacker, Army defender){ return new BattleServiceException(NOT_IN_SAME_REGION.formatted(defender.getName(), attacker.getName()));}
     public static BattleServiceException cannotAttackStarterHamlet() {return new BattleServiceException(CANNOT_ATTACK_STARTER_HAMLET);}
+    public static BattleServiceException noPlayerBound(String armyName) {return new BattleServiceException(NO_PLAYER_BOUND.formatted(armyName));}
     protected BattleServiceException(String message, Throwable rootCause) {
         super(message, rootCause);
     }

--- a/src/main/java/com/ardaslegends/service/war/BattleService.java
+++ b/src/main/java/com/ardaslegends/service/war/BattleService.java
@@ -35,6 +35,7 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
     private final WarRepository warRepository;
     private final Pathfinder pathfinder;
 
+    @Transactional(readOnly = false)
     public Battle createBattle(CreateBattleDto createBattleDto) {
         log.debug("Creating battle with data {}", createBattleDto);
         Objects.requireNonNull(createBattleDto, "CreateBattleDto must not be null");
@@ -52,6 +53,12 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         if (!ServiceUtils.boundLordLeaderPermission(executorPlayer, attackingArmy)) {
             log.warn("Player [{}] does not have the permission to start a battle with the army [{}]!", executorPlayer.getIgn(), createBattleDto.attackingArmyName());
             throw ArmyServiceException.noPermissionToPerformThisAction();
+        }
+
+        log.debug("Checking if army has a player bound to it");
+        if(attackingArmy.getBoundTo() == null) {
+            log.warn("Cannot declare battle because attacking army [{}] is not bound to a player", attackingArmy.getName());
+            throw BattleServiceException.noPlayerBound(attackingArmy.getName());
         }
 
         log.debug("Checking if army has enough health to start the battle");

--- a/src/main/java/com/ardaslegends/service/war/BattleService.java
+++ b/src/main/java/com/ardaslegends/service/war/BattleService.java
@@ -49,6 +49,12 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
         log.debug("Calling getArmyByName with name: [{}]", createBattleDto.attackingArmyName());
         Army attackingArmy = armyService.getArmyByName(createBattleDto.attackingArmyName());
 
+        log.debug("Checking if army is older than 24h");
+        if(attackingArmy.isYoungerThan24h()) {
+            log.warn("Army [{}] cannot declare battle because it was created less than 24h ago!", attackingArmy.getName());
+            throw BattleServiceException.armyYoungerThan24h(attackingArmy.getName());
+        }
+
         log.debug("Checking if player has permission to start the battle");
         if (!ServiceUtils.boundLordLeaderPermission(executorPlayer, attackingArmy)) {
             log.warn("Player [{}] does not have the permission to start a battle with the army [{}]!", executorPlayer.getIgn(), createBattleDto.attackingArmyName());

--- a/src/main/java/com/ardaslegends/service/war/BattleService.java
+++ b/src/main/java/com/ardaslegends/service/war/BattleService.java
@@ -128,15 +128,22 @@ public class BattleService extends AbstractService<Battle, BattleRepository> {
                 throw BattleServiceException.cannotAttackStarterHamlet();
             }
 
-            log.debug("Calling pathfinder to find shortest way from regions [{}] to [{}]", attackingArmy.getCurrentRegion(), battleRegion);
-            path = pathfinder.findShortestWay(attackingArmy.getCurrentRegion(), attackedClaimbuild.getRegion(),executorPlayer,true);
-            log.debug("Path: [{}], duration: [{} days]", ServiceUtils.buildPathString(path), ServiceUtils.getTotalPathCost(path));
 
-            log.debug("Checking if claimbuild is reachable in 24 hours");
-            if(ServiceUtils.getTotalPathCost(path) > 24){
-                log.warn("Cannot declare battle - Claimbuild [{}] is not in 24 hour reach of attacking army [{}]", attackedClaimbuild.getName(), attackingArmy.getName());
-                throw BattleServiceException.battleNotAbleDueHours();
+            if(!attackingArmy.getCurrentRegion().equals(attackedClaimbuild.getRegion())) {
+                log.debug("Army is not in region of claimbuild");
+                log.debug("Calling pathfinder to find shortest way from regions [{}] to [{}]", attackingArmy.getCurrentRegion(), battleRegion);
+                path = pathfinder.findShortestWay(attackingArmy.getCurrentRegion(), attackedClaimbuild.getRegion(),executorPlayer,true);
+                log.debug("Path: [{}], duration: [{} days]", ServiceUtils.buildPathString(path), ServiceUtils.getTotalPathCost(path));
+
+                log.debug("Checking if claimbuild is reachable in 24 hours");
+                if(ServiceUtils.getTotalPathCost(path) > 24){
+                    log.warn("Cannot declare battle - Claimbuild [{}] is not in 24 hour reach of attacking army [{}]", attackedClaimbuild.getName(), attackingArmy.getName());
+                    throw BattleServiceException.battleNotAbleDueHours();
+                }
             }
+            else
+                log.debug("Army [{}] is already in region [{}] of Claimbuild [{}]", attackingArmy.getName(), attackingArmy.getCurrentRegion().getId(), attackedClaimbuild.getName());
+
 
             if(stationedArmies.isEmpty())
                 log.debug("No armies stationed at claim build with name: [{}]", createBattleDto.claimBuildName());

--- a/src/test/java/com/ardaslegends/repository/ArmyRepositoryTest.java
+++ b/src/test/java/com/ardaslegends/repository/ArmyRepositoryTest.java
@@ -34,32 +34,32 @@ public class ArmyRepositoryTest {
     private RPChar rpChar;
     private ClaimBuild claimbuild;
 
-//    @BeforeEach
-//    void setup() {
-//        region1 = Region.builder().name("").id("1").regionType(RegionType.DESERT).build();
-//        val region2 = Region.builder().name("").id("2").regionType(RegionType.DESERT).build();
-//        val region3 = Region.builder().name("").id("3").regionType(RegionType.DESERT).build();
-//        val region4 = Region.builder().name("").id("4").regionType(RegionType.DESERT).build();
-//        val region5 = Region.builder().name("").id("5").regionType(RegionType.DESERT).build();
-//
-//        gondor = Faction.builder().name("Gondor").homeRegion(region1).build();
-//        rpChar = RPChar.builder().name("Belegorn").currentRegion(region1).build();
-//        var mordor = Faction.builder().name("Mordor").homeRegion(region2).build();
-//        claimbuild = ClaimBuild.builder().name("Nimheria").coordinates(new Coordinate(0,0,0)).ownedBy(gondor)
-//                .region(region1).type(ClaimBuildType.CASTLE).build();
-//
-//        factionRepository.saveAll(List.of(gondor, mordor));
-//    }
+    @BeforeEach
+    void setup() {
+        region1 = Region.builder().name("").id("1").regionType(RegionType.DESERT).build();
+        val region2 = Region.builder().name("").id("2").regionType(RegionType.DESERT).build();
+        val region3 = Region.builder().name("").id("3").regionType(RegionType.DESERT).build();
+        val region4 = Region.builder().name("").id("4").regionType(RegionType.DESERT).build();
+        val region5 = Region.builder().name("").id("5").regionType(RegionType.DESERT).build();
 
-//    @Test
-//    void ensureSaveArmyWorks() {
-//        val army = new Army("Army", ArmyType.ARMY, gondor, region1, rpChar, new ArrayList<>(),
-//                new ArrayList<>(), null, 0.0, false, null, null, 0, 0, claimbuild,
-//                OffsetDateTime.now(), true);
-//
-//        val result = armyRepository.save(army);
-//
-//        assertThat(result).isNotNull();
-//    }
+        gondor = Faction.builder().name("Gondor").homeRegion(region1).build();
+        rpChar = RPChar.builder().name("Belegorn").currentRegion(region1).build();
+        var mordor = Faction.builder().name("Mordor").homeRegion(region2).build();
+        claimbuild = ClaimBuild.builder().name("Nimheria").coordinates(new Coordinate(0,0,0)).ownedBy(gondor)
+                .region(region1).type(ClaimBuildType.CASTLE).build();
+
+        factionRepository.saveAll(List.of(gondor, mordor));
+    }
+
+    @Test
+    void ensureSaveArmyWorks() {
+        val army = new Army("Army", ArmyType.ARMY, gondor, region1, rpChar, new ArrayList<>(),
+                new ArrayList<>(), null, 0.0, false, null, null, 0, 0, claimbuild,
+                OffsetDateTime.now(), true);
+
+        val result = armyRepository.save(army);
+
+        assertThat(result).isNotNull();
+    }
 
 }

--- a/src/test/java/com/ardaslegends/repository/ArmyRepositoryTest.java
+++ b/src/test/java/com/ardaslegends/repository/ArmyRepositoryTest.java
@@ -34,32 +34,32 @@ public class ArmyRepositoryTest {
     private RPChar rpChar;
     private ClaimBuild claimbuild;
 
-    @BeforeEach
-    void setup() {
-        region1 = Region.builder().name("").id("1").regionType(RegionType.DESERT).build();
-        val region2 = Region.builder().name("").id("2").regionType(RegionType.DESERT).build();
-        val region3 = Region.builder().name("").id("3").regionType(RegionType.DESERT).build();
-        val region4 = Region.builder().name("").id("4").regionType(RegionType.DESERT).build();
-        val region5 = Region.builder().name("").id("5").regionType(RegionType.DESERT).build();
+//    @BeforeEach
+//    void setup() {
+//        region1 = Region.builder().name("").id("1").regionType(RegionType.DESERT).build();
+//        val region2 = Region.builder().name("").id("2").regionType(RegionType.DESERT).build();
+//        val region3 = Region.builder().name("").id("3").regionType(RegionType.DESERT).build();
+//        val region4 = Region.builder().name("").id("4").regionType(RegionType.DESERT).build();
+//        val region5 = Region.builder().name("").id("5").regionType(RegionType.DESERT).build();
+//
+//        gondor = Faction.builder().name("Gondor").homeRegion(region1).build();
+//        rpChar = RPChar.builder().name("Belegorn").currentRegion(region1).build();
+//        var mordor = Faction.builder().name("Mordor").homeRegion(region2).build();
+//        claimbuild = ClaimBuild.builder().name("Nimheria").coordinates(new Coordinate(0,0,0)).ownedBy(gondor)
+//                .region(region1).type(ClaimBuildType.CASTLE).build();
+//
+//        factionRepository.saveAll(List.of(gondor, mordor));
+//    }
 
-        gondor = Faction.builder().name("Gondor").homeRegion(region1).build();
-        rpChar = RPChar.builder().name("Belegorn").currentRegion(region1).build();
-        var mordor = Faction.builder().name("Mordor").homeRegion(region2).build();
-        claimbuild = ClaimBuild.builder().name("Nimheria").coordinates(new Coordinate(0,0,0)).ownedBy(gondor)
-                .region(region1).type(ClaimBuildType.CASTLE).build();
-
-        factionRepository.saveAll(List.of(gondor, mordor));
-    }
-
-    @Test
-    void ensureSaveArmyWorks() {
-        val army = new Army("Army", ArmyType.ARMY, gondor, region1, rpChar, new ArrayList<>(),
-                new ArrayList<>(), null, 0.0, false, null, null, 0, 0, claimbuild,
-                OffsetDateTime.now(), true);
-
-        val result = armyRepository.save(army);
-
-        assertThat(result).isNotNull();
-    }
+//    @Test
+//    void ensureSaveArmyWorks() {
+//        val army = new Army("Army", ArmyType.ARMY, gondor, region1, rpChar, new ArrayList<>(),
+//                new ArrayList<>(), null, 0.0, false, null, null, 0, 0, claimbuild,
+//                OffsetDateTime.now(), true);
+//
+//        val result = armyRepository.save(army);
+//
+//        assertThat(result).isNotNull();
+//    }
 
 }

--- a/src/test/java/com/ardaslegends/repository/ArmyRepositoryTest.java
+++ b/src/test/java/com/ardaslegends/repository/ArmyRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.ardaslegends.repository;
+
+import com.ardaslegends.domain.*;
+import com.ardaslegends.domain.war.Battle;
+import com.ardaslegends.domain.war.War;
+import com.ardaslegends.repository.faction.FactionRepository;
+import com.ardaslegends.repository.war.QueryWarStatus;
+import com.ardaslegends.repository.war.WarRepository;
+import io.vavr.collection.List;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(properties = {"spring.sql.init.mode=never"})
+@ActiveProfiles("test")
+public class ArmyRepositoryTest {
+
+    @Autowired
+    ArmyRepository armyRepository;
+    @Autowired
+    FactionRepository factionRepository;
+
+    private Faction gondor;
+    private Region region1;
+    private RPChar rpChar;
+    private ClaimBuild claimbuild;
+
+    @BeforeEach
+    void setup() {
+        region1 = Region.builder().name("").id("1").regionType(RegionType.DESERT).build();
+        val region2 = Region.builder().name("").id("2").regionType(RegionType.DESERT).build();
+        val region3 = Region.builder().name("").id("3").regionType(RegionType.DESERT).build();
+        val region4 = Region.builder().name("").id("4").regionType(RegionType.DESERT).build();
+        val region5 = Region.builder().name("").id("5").regionType(RegionType.DESERT).build();
+
+        gondor = Faction.builder().name("Gondor").homeRegion(region1).build();
+        rpChar = RPChar.builder().name("Belegorn").currentRegion(region1).build();
+        var mordor = Faction.builder().name("Mordor").homeRegion(region2).build();
+        claimbuild = ClaimBuild.builder().name("Nimheria").coordinates(new Coordinate(0,0,0)).ownedBy(gondor)
+                .region(region1).type(ClaimBuildType.CASTLE).build();
+
+        factionRepository.saveAll(List.of(gondor, mordor));
+    }
+
+    @Test
+    void ensureSaveArmyWorks() {
+        val army = new Army("Army", ArmyType.ARMY, gondor, region1, rpChar, new ArrayList<>(),
+                new ArrayList<>(), null, 0.0, false, null, null, 0, 0, claimbuild,
+                OffsetDateTime.now(), true);
+
+        val result = armyRepository.save(army);
+
+        assertThat(result).isNotNull();
+    }
+
+}

--- a/src/test/java/com/ardaslegends/repository/MovementRepositoryTest.java
+++ b/src/test/java/com/ardaslegends/repository/MovementRepositoryTest.java
@@ -55,7 +55,7 @@ public class MovementRepositoryTest {
         repository.save(movement2);
 
         log.trace("Calling query, expecting that a result is empty");
-        result = repository.findMovementByArmyAndIsCurrentlyActiveTrue(Army.builder().id(1L).name("Kek").build());
+        result = repository.findMovementByArmyAndIsCurrentlyActiveTrue(Army.builder().id(kekArmy.getId()).name(kekArmy.getName()).build());
         log.trace("Is Optional empty? [{}]", result.isEmpty());
         assertThat(result.isEmpty()).isTrue();
 
@@ -63,7 +63,7 @@ public class MovementRepositoryTest {
         repository.save(movement);
 
         log.trace("Calling query, expecting that a result is present");
-        result = repository.findMovementByArmyAndIsCurrentlyActiveTrue(Army.builder().id(1L).name("Kek").build());
+        result = repository.findMovementByArmyAndIsCurrentlyActiveTrue(Army.builder().id(kekArmy.getId()).name(kekArmy.getName()).build());
         log.trace("Is Optional present? [{}]", result.isPresent());
         assertThat(result.isPresent()).isTrue();
     }


### PR DESCRIPTION
This pull request adds missing features and bug fixed for the recently added `createBattle` method.

- `BattleRestController` with endpoint for `createBattle`
- Fix that the PathFinder is getting called when the army is already in target region
- Fix that battles can be declared without a bound player
- Fix that battles can be declared with recently raised armies
- Add missing '@Transactional' above `createBattle()`

Closes #158 