### PR TITLE
Bug/cannot fetch multiple active wars

### DIFF
--- a/src/main/java/com/ardaslegends/repository/exceptions/NotFoundException.java
+++ b/src/main/java/com/ardaslegends/repository/exceptions/NotFoundException.java
@@ -5,6 +5,7 @@ public class NotFoundException extends RepositoryException {
 
     private static final String GENERIC_COULD_NOT_FIND = "Could not find %s with %s %s!";
     private static final String NO_WAR_WITH_NAME = "No war with name '%s' found!";
+    private static final String NO_ACTIVE_WAR_WITH_NAME = "No active war with name '%s' found!";
 
     protected NotFoundException(String message) {
         super(message);
@@ -21,6 +22,7 @@ public class NotFoundException extends RepositoryException {
         return new NotFoundException(GENERIC_COULD_NOT_FIND.formatted(couldNotFind, with, value));
     }
     public static NotFoundException noWarWithNameFound(String name) {return new NotFoundException(NO_WAR_WITH_NAME.formatted(name));}
+    public static NotFoundException noActiveWarWithNameFound(String name) {return new NotFoundException(NO_ACTIVE_WAR_WITH_NAME.formatted(name));}
 
 
 }

--- a/src/main/java/com/ardaslegends/repository/war/WarRepository.java
+++ b/src/main/java/com/ardaslegends/repository/war/WarRepository.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 @Repository
 public interface WarRepository extends JpaRepository<War, Long>, WarRepositoryCustom {
-    public Optional<War> findByName(String name);
+    public Set<War> findByName(String name);
 
     @Query("""
             select w from War w 

--- a/src/main/java/com/ardaslegends/repository/war/WarRepositoryCustom.java
+++ b/src/main/java/com/ardaslegends/repository/war/WarRepositoryCustom.java
@@ -10,4 +10,5 @@ public interface WarRepositoryCustom {
     Set<War> queryWarsByFaction(Faction faction, QueryWarStatus warStatus);
     Set<War> queryWarsBetweenFactions(Faction faction1, Faction faction2, QueryWarStatus warStatus);
     Optional<War> queryActiveInitialWarBetween(Faction faction1, Faction faction2);
+    Optional<War> queryActiveWarByName(String name);
 }

--- a/src/main/java/com/ardaslegends/repository/war/WarRepositoryImpl.java
+++ b/src/main/java/com/ardaslegends/repository/war/WarRepositoryImpl.java
@@ -83,6 +83,19 @@ public class WarRepositoryImpl extends QuerydslRepositorySupport implements WarR
         return Optional.ofNullable(result);
     }
 
+    @Override
+    public Optional<War> queryActiveWarByName(String name) {
+        Objects.requireNonNull(name, "War name must not be null in queryActiveWarByName!");
+
+        QWar qWar = QWar.war;
+
+        val result = from(qWar)
+                .where(qWar.isActive.and(qWar.name.eq(name)))
+                .fetchFirst();
+
+        return Optional.ofNullable(result);
+    }
+
     private BooleanExpression activePredicate(QueryWarStatus warStatus) {
         Objects.requireNonNull(warStatus, "WarStatus must not be null");
         val war = QWar.war;

--- a/src/main/java/com/ardaslegends/service/exceptions/logic/war/WarServiceException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/logic/war/WarServiceException.java
@@ -12,6 +12,7 @@ public class WarServiceException extends LogicException {
     private static final String CANNOT_DECLARE_WAR_ON_YOUR_FACTION = "You cannot declare war on your own faction!";
     private static final String ALREADY_AT_WAR = "Your faction '%s' is already at war with '%s'!";
     private static final String WAR_NOT_ACTIVE = "The war '%s' is already over!";
+    private static final String ACTIVE_WAR_ALREADY_EXISTS = "There is already an active war called '%s'!";
 
     public static WarServiceException noWarDeclarationPermissions() { return new WarServiceException(NO_WAR_DECLARATION_PERMISSIONS); }
     public static WarServiceException factionAlreadyJoinedTheWarAsAttacker(String factionName) { return new WarServiceException(FACTION_ALREADY_JOINED_THE_WAR_AS_ATTACKER.formatted(factionName));}
@@ -20,6 +21,7 @@ public class WarServiceException extends LogicException {
     public static WarServiceException cannotDeclareWarOnYourFaction() { return new WarServiceException(CANNOT_DECLARE_WAR_ON_YOUR_FACTION); }
     public static WarServiceException alreadyAtWar(String executorFaction, String otherFaction) { return new WarServiceException(ALREADY_AT_WAR.formatted(executorFaction, otherFaction)); }
     public static WarServiceException warNotActive(String name) {return new WarServiceException(WAR_NOT_ACTIVE.formatted(name));}
+    public static WarServiceException activeWarAlreadyExists(String name) {return new WarServiceException(ACTIVE_WAR_ALREADY_EXISTS.formatted(name));}
 
     public WarServiceException(String message, Throwable rootCause) {
         super(message, rootCause);

--- a/src/main/java/com/ardaslegends/service/war/WarService.java
+++ b/src/main/java/com/ardaslegends/service/war/WarService.java
@@ -54,8 +54,11 @@ public class WarService extends AbstractService<War, WarRepository> {
         Objects.requireNonNull(createWarDto.nameOfWar(), "Name of War must not be null");
         Objects.requireNonNull(createWarDto.defendingFactionName(), "Defending Faction Name must not be null");
 
-        val warWithName = warRepository.find
-        if()
+        val activeWarWithName = warRepository.queryActiveWarByName(createWarDto.nameOfWar());
+        if(activeWarWithName.isPresent()) {
+            log.warn("Cannot create war because active war with name [{}] already exists!", createWarDto.nameOfWar());
+            throw WarServiceException.activeWarAlreadyExists(createWarDto.nameOfWar());
+        }
 
         log.trace("Fetching player with discordId [{}]", createWarDto.executorDiscordId());
         var executorPlayer = playerService.getPlayerByDiscordId(createWarDto.executorDiscordId());


### PR DESCRIPTION
The `fetchWarByName` query was assuming that the war name is unique, which is actually incorrect.
This fix now changed this query to return a set and also introduced a new query called `queryActiveWarByName`, which returns exactly one war.
When creating wars you cannot create a war if there is already an active war with the same name