### PR TITLE
Only using unitString when it is present in ArmyRestController

### DIFF
--- a/src/main/java/com/ardaslegends/presentation/api/ArmyRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/ArmyRestController.java
@@ -55,10 +55,13 @@ public class ArmyRestController extends AbstractRestController {
     public HttpEntity<ArmyResponse> createArmy(@RequestBody CreateArmyDto dto) {
         log.debug("Incoming createArmy Request: Data [{}]", dto);
 
-        var units = armyService.convertUnitInputIntoUnits(dto.unitString());
-        CreateArmyDto dtoWithUnits = new CreateArmyDto(dto.executorDiscordId(), dto.name(), dto.armyType(), dto.claimBuildName(), units);
+        if(dto.unitString() != null) {
+            log.debug("Found unitString in CreateArmyDto, building units from string");
+            var units = armyService.convertUnitInputIntoUnits(dto.unitString());
+            dto = new CreateArmyDto(dto.executorDiscordId(), dto.name(), dto.armyType(), dto.claimBuildName(), units);
+        }
         log.debug("Calling ArmyService.createArmy");
-        Army createdArmy = armyService.createArmy(dtoWithUnits);
+        Army createdArmy = armyService.createArmy(dto);
         log.debug("Converting to ArmyResponse");
         ArmyResponse response = new ArmyResponse(createdArmy);
 


### PR DESCRIPTION
The `unitString` in a create army REST request will only be used if it is present. If not, then the units must be present inside the `units[]` array.