### PR TITLE
Implemented getCbByFaction route

### DIFF
--- a/src/main/java/com/ardaslegends/presentation/api/ClaimbuildRestController.java
+++ b/src/main/java/com/ardaslegends/presentation/api/ClaimbuildRestController.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 public class ClaimbuildRestController extends AbstractRestController {
     public static final String BASE_URL = "/api/claimbuild";
     public static final String NAME = "/name";
+    public static final String FACTION = "/faction";
     public static final String GET_TYPES = "/types";
     public static final String GET_SPECIAL_BUILDINGS = "/specialbuildings";
     public static final String PATH_CREATE_CLAIMBUILD = "/create";
@@ -69,6 +70,19 @@ public class ClaimbuildRestController extends AbstractRestController {
         log.debug("Incoming getClaimbuildsByName Request, parameter names: [{}]", (Object) names);
 
         List<ClaimBuild> claimBuilds = claimBuildService.getClaimBuildsByNames(names);
+
+        log.debug("Building ClaimbuildResponses with claimbuilds [{}]", claimBuilds);
+        ClaimbuildResponse[] response = claimBuilds.stream().map(ClaimbuildResponse::new).toArray(ClaimbuildResponse[]::new);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Get Claimbuilds By Faction", description = "Returns an array of claimbuilds of the specified faction")
+    @GetMapping(FACTION)
+    public ResponseEntity<ClaimbuildResponse[]> getClaimbuildsByFaction(@RequestParam String faction) {
+        log.debug("Incoming getClaimbuildsByFaction Request, parameter faction: [{}]", faction);
+
+        List<ClaimBuild> claimBuilds = claimBuildService.getClaimBuildsByFaction(faction);
 
         log.debug("Building ClaimbuildResponses with claimbuilds [{}]", claimBuilds);
         ClaimbuildResponse[] response = claimBuilds.stream().map(ClaimbuildResponse::new).toArray(ClaimbuildResponse[]::new);

--- a/src/main/java/com/ardaslegends/repository/claimbuild/ClaimbuildRepositoryCustom.java
+++ b/src/main/java/com/ardaslegends/repository/claimbuild/ClaimbuildRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.ardaslegends.repository.claimbuild;
 
 import com.ardaslegends.domain.ClaimBuild;
+import com.ardaslegends.domain.Faction;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +11,6 @@ public interface ClaimbuildRepositoryCustom {
     Optional<ClaimBuild> queryByNameIgnoreCaseOptional(String claimbuildName);
     boolean existsByNameIgnoreCase(String claimbuildName);
     List<ClaimBuild> findClaimBuildsByNames(String[] names);
+    List<ClaimBuild> findClaimBuildsByFaction(Faction faction);
 
 }

--- a/src/main/java/com/ardaslegends/repository/claimbuild/ClaimbuildRepositoryCustom.java
+++ b/src/main/java/com/ardaslegends/repository/claimbuild/ClaimbuildRepositoryCustom.java
@@ -10,7 +10,7 @@ public interface ClaimbuildRepositoryCustom {
     ClaimBuild queryByNameIgnoreCase(String claimbuildName);
     Optional<ClaimBuild> queryByNameIgnoreCaseOptional(String claimbuildName);
     boolean existsByNameIgnoreCase(String claimbuildName);
-    List<ClaimBuild> findClaimBuildsByNames(String[] names);
-    List<ClaimBuild> findClaimBuildsByFaction(Faction faction);
+    List<ClaimBuild> queryByNames(String[] names);
+    List<ClaimBuild> queryByFaction(Faction faction);
 
 }

--- a/src/main/java/com/ardaslegends/repository/claimbuild/ClaimbuildRepositoryImpl.java
+++ b/src/main/java/com/ardaslegends/repository/claimbuild/ClaimbuildRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.ardaslegends.repository.claimbuild;
 
 import com.ardaslegends.domain.ClaimBuild;
+import com.ardaslegends.domain.Faction;
 import com.ardaslegends.domain.QClaimBuild;
 import com.ardaslegends.repository.exceptions.ClaimbuildRepositoryException;
+import com.ardaslegends.repository.exceptions.RepositoryNullPointerException;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
@@ -60,6 +62,24 @@ public class ClaimbuildRepositoryImpl extends QuerydslRepositorySupport implemen
 
         log.debug("Queried claimbuilds: [{}]", fetchedClaimbuilds);
 
+        return fetchedClaimbuilds;
+    }
+
+    @Override
+    public List<ClaimBuild> findClaimBuildsByFaction(Faction faction) {
+        log.debug("Querying claimbuilds of faction [{}]", faction);
+        if(faction == null) {
+            log.warn("Faction was null in findClaimBuildsByFaction!");
+            throw RepositoryNullPointerException.queryMethodParameterWasNull("faction", "findClaimBuildsByFaction");
+        }
+
+        QClaimBuild qClaimBuild = QClaimBuild.claimBuild;
+
+        val fetchedClaimbuilds = from(qClaimBuild)
+                .where(qClaimBuild.ownedBy.name.eq(faction.getName()))
+                .stream().toList();
+
+        log.debug("Queried claimbuilds: [{}]", fetchedClaimbuilds);
         return fetchedClaimbuilds;
     }
 

--- a/src/main/java/com/ardaslegends/repository/claimbuild/ClaimbuildRepositoryImpl.java
+++ b/src/main/java/com/ardaslegends/repository/claimbuild/ClaimbuildRepositoryImpl.java
@@ -50,7 +50,7 @@ public class ClaimbuildRepositoryImpl extends QuerydslRepositorySupport implemen
     }
 
     @Override
-    public List<ClaimBuild> findClaimBuildsByNames(String[] names) {
+    public List<ClaimBuild> queryByNames(String[] names) {
         log.debug("Querying claimbuilds by names: {}", names);
         Objects.requireNonNull(names, "Names must not be null");
         QClaimBuild qClaimBuild = QClaimBuild.claimBuild;
@@ -66,7 +66,7 @@ public class ClaimbuildRepositoryImpl extends QuerydslRepositorySupport implemen
     }
 
     @Override
-    public List<ClaimBuild> findClaimBuildsByFaction(Faction faction) {
+    public List<ClaimBuild> queryByFaction(Faction faction) {
         log.debug("Querying claimbuilds of faction [{}]", faction);
         if(faction == null) {
             log.warn("Faction was null in findClaimBuildsByFaction!");

--- a/src/main/java/com/ardaslegends/service/ClaimBuildService.java
+++ b/src/main/java/com/ardaslegends/service/ClaimBuildService.java
@@ -12,6 +12,7 @@ import com.ardaslegends.service.exceptions.logic.claimbuild.ClaimBuildServiceExc
 import com.ardaslegends.service.utils.ServiceUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -245,6 +246,27 @@ public class ClaimBuildService extends AbstractService<ClaimBuild, ClaimbuildRep
         }
 
         log.debug("Successfully returning Claimbuilds found with names [{}]", (Object) names);
+        return fetchedClaimbuilds;
+    }
+
+    public List<ClaimBuild> getClaimBuildsByFaction(String factionName) {
+        log.debug("Getting Claimbuilds of faction [{}]", factionName);
+
+        Objects.requireNonNull(factionName, "FactionName must not be null");
+        ServiceUtils.checkBlankString(factionName, "faction");
+
+        log.debug("Getting faction [{}]", factionName);
+        val faction = factionService.getFactionByName(factionName);
+
+        log.debug("Fetching claimbuilds of faction [{}]", factionName);
+        List<ClaimBuild> fetchedClaimbuilds = secureFind(faction, claimbuildRepository::findClaimBuildsByFaction);
+
+        if(fetchedClaimbuilds.isEmpty()) {
+            log.warn("No Claimbuild found for faction [{}]", faction);
+            throw ClaimBuildServiceException.factionHasNoCbs(factionName);
+        }
+
+        log.debug("Successfully returning Claimbuilds found for faction [{}]", faction);
         return fetchedClaimbuilds;
     }
 

--- a/src/main/java/com/ardaslegends/service/ClaimBuildService.java
+++ b/src/main/java/com/ardaslegends/service/ClaimBuildService.java
@@ -238,7 +238,7 @@ public class ClaimBuildService extends AbstractService<ClaimBuild, ClaimbuildRep
         Arrays.stream(names).forEach(str -> ServiceUtils.checkBlankString(str, "Name"));
 
         log.debug("Fetching claimbuilds with names [{}]", (Object) names);
-        List<ClaimBuild> fetchedClaimbuilds = secureFind(names, claimbuildRepository::findClaimBuildsByNames);
+        List<ClaimBuild> fetchedClaimbuilds = secureFind(names, claimbuildRepository::queryByNames);
 
         if(fetchedClaimbuilds.isEmpty()) {
             log.warn("No Claimbuild found with names [{}]", (Object) names);
@@ -259,7 +259,7 @@ public class ClaimBuildService extends AbstractService<ClaimBuild, ClaimbuildRep
         val faction = factionService.getFactionByName(factionName);
 
         log.debug("Fetching claimbuilds of faction [{}]", factionName);
-        List<ClaimBuild> fetchedClaimbuilds = secureFind(faction, claimbuildRepository::findClaimBuildsByFaction);
+        List<ClaimBuild> fetchedClaimbuilds = secureFind(faction, claimbuildRepository::queryByFaction);
 
         if(fetchedClaimbuilds.isEmpty()) {
             log.warn("No Claimbuild found for faction [{}]", faction);

--- a/src/main/java/com/ardaslegends/service/exceptions/logic/claimbuild/ClaimBuildServiceException.java
+++ b/src/main/java/com/ardaslegends/service/exceptions/logic/claimbuild/ClaimBuildServiceException.java
@@ -5,6 +5,7 @@ import com.ardaslegends.service.exceptions.logic.LogicException;
 public class ClaimBuildServiceException extends LogicException {
 
     private static final String NO_CB_WITH_NAME = "Found no claimbuild with name '%s'!";
+    private static final String NO_CB_FOR_FACTION = "Faction '%s' has no claimbuilds!";
     private static final String DIFFERENT_FACTION = "The claimbuild '%s' is part of a different faction ('%s') - you cannot interact with it!";
     private static final String DIFFERENT_FACTION_NOT_ALLIED = "The claimbuild '%s' is part of the faction '%s' - you are not allied with '%s' and therefore cannot interact with it!";
     private static final String REGION_IS_NOT_CLAIMABLE_FOR_FACTION = "Region '%s' is not claimable for the faction '%s' because the region is not unclaimed and the faction does not have a Claimbuild already in that region.";
@@ -26,6 +27,7 @@ public class ClaimBuildServiceException extends LogicException {
             "Actual Grammar=[Player]-[Player2]-[Player3]";
 
     public static ClaimBuildServiceException noCbWithName(String cbName) { return new ClaimBuildServiceException(NO_CB_WITH_NAME.formatted(cbName)); }
+    public static ClaimBuildServiceException factionHasNoCbs(String factionName) { return new ClaimBuildServiceException(NO_CB_FOR_FACTION.formatted(factionName)); }
     public static ClaimBuildServiceException differentFaction(String cbName, String factionName) { return new ClaimBuildServiceException(DIFFERENT_FACTION.formatted(cbName, factionName)); }
     public static ClaimBuildServiceException differentFactionNotAllied(String cbName, String factionName) { return new ClaimBuildServiceException(DIFFERENT_FACTION_NOT_ALLIED.formatted(cbName, factionName, factionName)); }
     public static ClaimBuildServiceException regionIsNotClaimableForFaction(String regionId, String factionName) {return new ClaimBuildServiceException(REGION_IS_NOT_CLAIMABLE_FOR_FACTION.formatted(regionId,factionName));}


### PR DESCRIPTION
Added a new `/api/claimbuild/faction` route which uses a `faction: String` query parameter to get all the claimbuilds of the passed faction